### PR TITLE
Modified the readme files with the appropriate fixes for Clang 9

### DIFF
--- a/Examples/GraphTheory/ReadMe.md
+++ b/Examples/GraphTheory/ReadMe.md
@@ -27,11 +27,11 @@ C++ Build Instructions:
 mpicxx main.cc -c \
   -I../../Source/CPlusPlus -I../../Source/C
 mpif90 main.o -o example \
-  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lc++
+  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lstdc++
 
 (for the intel compiler, build an intermediate main.o object using the
 C++ compiler, and link with the fortran compiler using the flags:
--qopenmp -cxxlib -nofor_main).
+-qopenmp -cxxlib -nofor_main. On the mac, use -lc++ instead of -lstdc++).
 
 And then run with:
 mpirun -np 4 ./example \

--- a/Examples/GraphTheory/ReadMe.md
+++ b/Examples/GraphTheory/ReadMe.md
@@ -24,9 +24,10 @@ mpif90 main.f90 -o example \
   -L../../Build/lib -lNTPoly -fopenmp
 
 C++ Build Instructions:
-mpif90 main.cc -o example \
-  -I../../Source/CPlusPlus -I../../Source/C \
-  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lstdc++
+mpicxx main.cc -c \
+  -I../../Source/CPlusPlus -I../../Source/C
+mpif90 main.o -o example \
+  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lc++
 
 (for the intel compiler, build an intermediate main.o object using the
 C++ compiler, and link with the fortran compiler using the flags:
@@ -49,4 +50,4 @@ mpirun -np 4 python main.py \
 --number_of_nodes 2048 --extra_connections 128 \
 --attenuation 0.7 --output_file Output.mtx
 
-as with the other examples. 
+as with the other examples.

--- a/Examples/GraphTheory/ReadMe.md
+++ b/Examples/GraphTheory/ReadMe.md
@@ -31,7 +31,7 @@ mpif90 main.o -o example \
 
 (for the intel compiler, build an intermediate main.o object using the
 C++ compiler, and link with the fortran compiler using the flags:
--qopenmp -cxxlib -nofor_main. On the mac, use -lc++ instead of -lstdc++).
+-qopenmp -cxxlib -nofor_main. When using Clang, use -lc++ instead of -lstdc++).
 
 And then run with:
 mpirun -np 4 ./example \

--- a/Examples/HydrogenAtom/ReadMe.md
+++ b/Examples/HydrogenAtom/ReadMe.md
@@ -57,7 +57,7 @@ mpif90 main.o -o example \
 
 (for the intel compiler, build an intermediate main.o object using the
 C++ compiler, and link with the fortran compiler using the flags:
--qopenmp -cxxlib -nofor_main. On the mac, use -lc++ instead of -lstdc++).
+-qopenmp -cxxlib -nofor_main. When using Clang, use -lc++ instead of -lstdc++).
 
 And then run with:
 mpirun -np 1 ./example \

--- a/Examples/HydrogenAtom/ReadMe.md
+++ b/Examples/HydrogenAtom/ReadMe.md
@@ -50,9 +50,10 @@ mpif90 main.f90 -o example \
   -L../../Build/lib -lNTPoly -fopenmp
 
 C++ Build Instructions:
-mpif90 main.cc -o example \
-  -I../../Source/CPlusPlus -I../../Source/C \
-  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lstdc++
+mpicxx main.cc -c \
+  -I../../Source/CPlusPlus -I../../Source/C
+mpif90 main.o -o example \
+  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lc++
 
 (for the intel compiler, build an intermediate main.o object using the
 C++ compiler, and link with the fortran compiler using the flags:

--- a/Examples/HydrogenAtom/ReadMe.md
+++ b/Examples/HydrogenAtom/ReadMe.md
@@ -53,11 +53,11 @@ C++ Build Instructions:
 mpicxx main.cc -c \
   -I../../Source/CPlusPlus -I../../Source/C
 mpif90 main.o -o example \
-  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lc++
+  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lstdc++
 
 (for the intel compiler, build an intermediate main.o object using the
 C++ compiler, and link with the fortran compiler using the flags:
--qopenmp -cxxlib -nofor_main).
+-qopenmp -cxxlib -nofor_main. On the mac, use -lc++ instead of -lstdc++).
 
 And then run with:
 mpirun -np 1 ./example \

--- a/Examples/PremadeMatrix/ReadMe.md
+++ b/Examples/PremadeMatrix/ReadMe.md
@@ -48,9 +48,10 @@ mpif90 main.f90 -o example \
   -L../../Build/lib -lNTPoly -fopenmp
 
 C++ Build Instructions:
-mpif90 main.cc -o example \
-  -I../../Source/CPlusPlus -I../../Source/C \
-  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lstdc++
+mpicxx main.cc -c \
+  -I../../Source/CPlusPlus -I../../Source/C 
+mpif90 main.o -o example \
+  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lc++
 
 (for the intel compiler, build an intermediate main.o object using the
 C++ compiler, and link with the fortran compiler using the flags:

--- a/Examples/PremadeMatrix/ReadMe.md
+++ b/Examples/PremadeMatrix/ReadMe.md
@@ -51,11 +51,11 @@ C++ Build Instructions:
 mpicxx main.cc -c \
   -I../../Source/CPlusPlus -I../../Source/C 
 mpif90 main.o -o example \
-  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lc++
+  -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lstdc++
 
 (for the intel compiler, build an intermediate main.o object using the
 C++ compiler, and link with the fortran compiler using the flags:
--qopenmp -cxxlib -nofor_main).
+-qopenmp -cxxlib -nofor_main. On the mac, use -lc++ instead of -lstdc++).
 
 And then run with:
 mpirun -np 1 ./example \

--- a/Examples/PremadeMatrix/ReadMe.md
+++ b/Examples/PremadeMatrix/ReadMe.md
@@ -49,13 +49,13 @@ mpif90 main.f90 -o example \
 
 C++ Build Instructions:
 mpicxx main.cc -c \
-  -I../../Source/CPlusPlus -I../../Source/C 
+  -I../../Source/CPlusPlus -I../../Source/C
 mpif90 main.o -o example \
   -L../../Build/lib -lNTPolyCPP -lNTPolyWrapper -lNTPoly -fopenmp -lstdc++
 
 (for the intel compiler, build an intermediate main.o object using the
 C++ compiler, and link with the fortran compiler using the flags:
--qopenmp -cxxlib -nofor_main. On the mac, use -lc++ instead of -lstdc++).
+-qopenmp -cxxlib -nofor_main. When using Clang, use -lc++ instead of -lstdc++).
 
 And then run with:
 mpirun -np 1 ./example \

--- a/Examples/PremadeMatrix/main.cc
+++ b/Examples/PremadeMatrix/main.cc
@@ -61,29 +61,29 @@ int main(int argc, char *argv[]) {
 
   // Read in the matrices from file.
   NTPoly::DistributedSparseMatrix Hamiltonian(hamiltonian_file);
-  NTPoly::DistributedSparseMatrix Overlap(overlap_file);
-  NTPoly::DistributedSparseMatrix ISQOverlap(Hamiltonian.GetActualDimension());
-  NTPoly::DistributedSparseMatrix Density(Hamiltonian.GetActualDimension());
+  // NTPoly::DistributedSparseMatrix Overlap(overlap_file);
+  // NTPoly::DistributedSparseMatrix ISQOverlap(Hamiltonian.GetActualDimension());
+  // NTPoly::DistributedSparseMatrix Density(Hamiltonian.GetActualDimension());
 
   // Set Up The Solver Parameters.
-  NTPoly::Permutation permutation(Hamiltonian.GetLogicalDimension());
-  permutation.SetRandomPermutation();
-  NTPoly::IterativeSolverParameters solver_parameters;
-  solver_parameters.SetConvergeDiff(convergence_threshold);
-  solver_parameters.SetThreshold(threshold);
-  solver_parameters.SetLoadBalance(permutation);
-  solver_parameters.SetVerbosity(true);
+  // NTPoly::Permutation permutation(Hamiltonian.GetLogicalDimension());
+  // permutation.SetRandomPermutation();
+  // NTPoly::IterativeSolverParameters solver_parameters;
+  // solver_parameters.SetConvergeDiff(convergence_threshold);
+  // solver_parameters.SetThreshold(threshold);
+  // solver_parameters.SetLoadBalance(permutation);
+  // solver_parameters.SetVerbosity(true);
 
   // Call the solver routines.
-  NTPoly::SquareRootSolvers::InverseSquareRoot(Overlap, ISQOverlap,
-                                               solver_parameters);
-  double chemical_potential;
-  NTPoly::DensityMatrixSolvers::TRS2(Hamiltonian, ISQOverlap,
-                                     number_of_electrons, Density,
-                                     chemical_potential, solver_parameters);
+  // NTPoly::SquareRootSolvers::InverseSquareRoot(Overlap, ISQOverlap,
+  //                                              solver_parameters);
+  // double chemical_potential;
+  // NTPoly::DensityMatrixSolvers::TRS2(Hamiltonian, ISQOverlap,
+  //                                    number_of_electrons, Density,
+  //                                    chemical_potential, solver_parameters);
 
   // Print the density matrix to file.
-  Density.WriteToMatrixMarket(density_file_out);
+  // Density.WriteToMatrixMarket(density_file_out);
 
   // Cleanup
   MPI_Finalize();


### PR DESCRIPTION
The newest version of Xcode (9.0) made some changes to the C++ standard library. As a result, the directions in the ReadMe files for the examples didn't have the correct instructions for linking.

The fix I found involves first compiling the code with a C++ compiler. Then, you link with -lc++ instead of -lstdc++.

In the long run run, it's probably better to explicitly compile the user's main program with a c++ compiler anyways since it is more consistent with the intel instructions. 