### PR TITLE
Moved types above the interface.

### DIFF
--- a/Source/Fortran/TripletListModule.F90
+++ b/Source/Fortran/TripletListModule.F90
@@ -9,6 +9,22 @@ MODULE TripletListModule
   USE, INTRINSIC :: ISO_C_BINDING, ONLY : c_int
   IMPLICIT NONE
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !> A data type for a list of triplets.
+  TYPE :: TripletList_r
+     !> Internal representation of the data.
+     TYPE(Triplet_r), DIMENSION(:), ALLOCATABLE :: DATA
+     !> Current number of elements in the triplet list
+     INTEGER :: CurrentSize
+  END TYPE TripletList_r
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !> A data type for a list of triplets.
+  TYPE :: TripletList_c
+     !> Internal representation of the data.
+     TYPE(Triplet_c), DIMENSION(:), ALLOCATABLE :: DATA
+     !> Current number of elements in the triplet list
+     INTEGER :: CurrentSize
+  END TYPE TripletList_c
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   PUBLIC :: TripletList_r
   PUBLIC :: TripletList_c
   PUBLIC :: ConstructTripletList
@@ -87,22 +103,6 @@ MODULE TripletListModule
      MODULE PROCEDURE ConvertTripletListToReal
      MODULE PROCEDURE ConvertTripletListToComplex
   END INTERFACE
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  !> A data type for a list of triplets.
-  TYPE :: TripletList_r
-     !> Internal representation of the data.
-     TYPE(Triplet_r), DIMENSION(:), ALLOCATABLE :: DATA
-     !> Current number of elements in the triplet list
-     INTEGER :: CurrentSize
-  END TYPE TripletList_r
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  !> A data type for a list of triplets.
-  TYPE :: TripletList_c
-     !> Internal representation of the data.
-     TYPE(Triplet_c), DIMENSION(:), ALLOCATABLE :: DATA
-     !> Current number of elements in the triplet list
-     INTEGER :: CurrentSize
-  END TYPE TripletList_c
 CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> Subroutine wrapper for constructing a triplet list.
   PURE SUBROUTINE ConstructTripletListSup_r(this, size_in)

--- a/Source/Fortran/TripletModule.F90
+++ b/Source/Fortran/TripletModule.F90
@@ -8,6 +8,24 @@ MODULE TripletModule
   IMPLICIT NONE
   PRIVATE
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !> A data type for a triplet of integer, integer, double.
+  !> As this is related to matrix multiplication, the referencing indices are
+  !> rows and columns.
+  TYPE, PUBLIC :: Triplet_r
+     INTEGER(kind=c_int) :: index_column !< column value.
+     INTEGER(kind=c_int) :: index_row    !< row value.
+     REAL(NTREAL)        :: point_value  !< actual value at those indices.
+  END TYPE Triplet_r
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !> A data type for a triplet of integer, integer, complex.
+  !> As this is related to matrix multiplication, the referencing indices are
+  !> rows and columns.
+  TYPE, PUBLIC :: Triplet_c
+     INTEGER(kind=c_int) :: index_column !< column value.
+     INTEGER(kind=c_int) :: index_row    !< row value.
+     COMPLEX(NTCOMPLEX)  :: point_value  !< actual value at those indices.
+  END TYPE Triplet_c
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   PUBLIC :: SetTriplet
   PUBLIC :: GetTripletValues
   PUBLIC :: CompareTriplets
@@ -31,24 +49,6 @@ MODULE TripletModule
      MODULE PROCEDURE ConvertTripletToReal
      MODULE PROCEDURE ConvertTripletToComplex
   END INTERFACE
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  !> A data type for a triplet of integer, integer, double.
-  !> As this is related to matrix multiplication, the referencing indices are
-  !> rows and columns.
-  TYPE, PUBLIC :: Triplet_r
-     INTEGER(kind=c_int) :: index_column !< column value.
-     INTEGER(kind=c_int) :: index_row    !< row value.
-     REAL(NTREAL)        :: point_value  !< actual value at those indices.
-  END TYPE Triplet_r
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  !> A data type for a triplet of integer, integer, complex.
-  !> As this is related to matrix multiplication, the referencing indices are
-  !> rows and columns.
-  TYPE, PUBLIC :: Triplet_c
-     INTEGER(kind=c_int) :: index_column !< column value.
-     INTEGER(kind=c_int) :: index_row    !< row value.
-     COMPLEX(NTCOMPLEX)  :: point_value  !< actual value at those indices.
-  END TYPE Triplet_c
 CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> Set the values of a triplet.
   PURE SUBROUTINE SetTriplet_r(this,index_column,index_row,point_value)


### PR DESCRIPTION
For consistency, I have moved the type definitions to all be
before the interface. The order is now:

Type
Public Functions
Interfaces