### PR TITLE
Add a few deallocate statements

### DIFF
--- a/Source/Fortran/PermutationModule.F90
+++ b/Source/Fortran/PermutationModule.F90
@@ -32,6 +32,8 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !! Local Data
     INTEGER :: counter
 
+    CALL DestructPermutation(this)
+
     ALLOCATE(this%index_lookup(matrix_dimension))
     ALLOCATE(this%reverse_index_lookup(matrix_dimension))
 
@@ -51,6 +53,8 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     INTEGER, INTENT(IN) :: matrix_dimension
     !! Local Data
     INTEGER :: counter
+
+    CALL DestructPermutation(this)
 
     ALLOCATE(this%index_lookup(matrix_dimension))
     ALLOCATE(this%reverse_index_lookup(matrix_dimension))

--- a/Source/Fortran/ProcessGridModule.F90
+++ b/Source/Fortran/ProcessGridModule.F90
@@ -633,7 +633,7 @@ CONTAINS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> Pick an appropriate number of process slices for this calculation.
   !> This routine will focus on whether we can make a valid process grid with
-  !> several slices. 
+  !> several slices.
   SUBROUTINE ComputeNumSlices(total_processors, slices)
     !> Total processors in the grid.
     INTEGER, INTENT(IN) :: total_processors

--- a/Source/Fortran/TripletListModule.F90
+++ b/Source/Fortran/TripletListModule.F90
@@ -8,6 +8,7 @@ MODULE TripletListModule
   USE MatrixMarketModule, ONLY : MM_SYMMETRIC, MM_SKEW_SYMMETRIC, MM_HERMITIAN
   USE, INTRINSIC :: ISO_C_BINDING, ONLY : c_int
   IMPLICIT NONE
+  PRIVATE
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> A data type for a list of triplets.
   TYPE :: TripletList_r

--- a/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
+++ b/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
@@ -249,6 +249,9 @@
   DEALLOCATE(row_helper)
   DEALLOCATE(column_helper)
   DEALLOCATE(slice_helper)
+  DEALLOCATE(ATasks)
+  DEALLOCATE(BTasks)
+  DEALLOCATE(ABTasks)
 
   !! Deallocate Buffers From A
   DO II=1,matAB%process_grid%number_of_blocks_rows

--- a/Source/Fortran/solver_includes/AppendToVector.f90
+++ b/Source/Fortran/solver_includes/AppendToVector.f90
@@ -1,4 +1,4 @@
-  
+
   values_per = values_per + 1
   indices(values_per) = insert_row
   values(values_per) = insert_value

--- a/Source/Fortran/sparse_includes/PruneList.f90
+++ b/Source/Fortran/sparse_includes/PruneList.f90
@@ -37,3 +37,4 @@
   CALL ConstructMatrixFromTripletList(matAB, sorted_pruned_list, mat_c_rows, &
        & mat_c_columns)
   CALL DestructTripletList(sorted_pruned_list)
+  CALL DestructTripletList(unsorted_pruned_list)


### PR DESCRIPTION
@william-dawson  This is to dismiss some warnings from NAG Fortran. I'm not sure if you are ok with adding `CALL DestructPermutation(this)` to `PermutationModule.F90`. Please let me know : )