### PR TITLE
Fixes for writing to matrix market

### DIFF
--- a/Source/Fortran/MatrixMarketModule.F90
+++ b/Source/Fortran/MatrixMarketModule.F90
@@ -136,7 +136,7 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     END IF
 
     !! Combine
-    WRITE(outstring, *) ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
+    WRITE(outstring, '(A A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
          & ADJUSTL(TRIM(temp3))
 
   END SUBROUTINE WriteMMSize
@@ -168,10 +168,10 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1)), &
-            & ADJUSTL(TRIM(temp2))//NEW_LINE('A')
+       WRITE(outstring, '(A A A)') ADJUSTL(TRIM(temp1)), &
+            & ADJUSTL(TRIM(temp2)) // NEW_LINE('A')
     ELSE
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2))
+       WRITE(outstring, '(A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2))
     END IF
   END SUBROUTINE WriteMMLine_ii
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -205,10 +205,10 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
-            & ADJUSTL(TRIM(temp3))//NEW_LINE('A')
+       WRITE(outstring, '(A A A A)') ADJUSTL(TRIM(temp1)), &
+            & ADJUSTL(TRIM(temp2)), ADJUSTL(TRIM(temp3)) // NEW_LINE('A')
     ELSE
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
+       WRITE(outstring, '(A A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
             & ADJUSTL(TRIM(temp3))
     END IF
   END SUBROUTINE WriteMMLine_iif
@@ -247,11 +247,11 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1)), &
+       WRITE(outstring, '(A A A A A)') ADJUSTL(TRIM(temp1)), &
             & ADJUSTL(TRIM(temp2)), ADJUSTL(TRIM(temp3)), &
-            & ADJUSTL(TRIM(temp4))//NEW_LINE('A')
+            & ADJUSTL(TRIM(temp4)) // NEW_LINE('A')
     ELSE
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1)), &
+       WRITE(outstring, '(A A A A)') ADJUSTL(TRIM(temp1)), &
             & ADJUSTL(TRIM(temp2)), ADJUSTL(TRIM(temp3)), ADJUSTL(TRIM(temp4))
     END IF
   END SUBROUTINE WriteMMLine_iiff
@@ -280,9 +280,9 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1))//NEW_LINE('A')
+       WRITE(outstring, '(A A)') ADJUSTL(TRIM(temp1)) // NEW_LINE('A')
     ELSE
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1))
+       WRITE(outstring, '(A)') ADJUSTL(TRIM(temp1))
     END IF
   END SUBROUTINE WriteMMLine_f
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -313,10 +313,10 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)) &
-            & //NEW_LINE('A')
+       WRITE(outstring, '(A A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)) &
+            & // NEW_LINE('A')
     ELSE
-       WRITE(outstring, *) ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2))
+       WRITE(outstring, '(A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2))
     END IF
   END SUBROUTINE WriteMMLine_ff
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/Source/Fortran/distributed_includes/WriteToMatrixMarket.f90
+++ b/Source/Fortran/distributed_includes/WriteToMatrixMarket.f90
@@ -110,27 +110,34 @@
 
   !! Global Write
   IF (this%process_grid%between_slice_rank .EQ. 0) THEN
-     CALL MPI_File_open(this%process_grid%within_slice_comm,file_name, &
-          & IOR(MPI_MODE_CREATE,MPI_MODE_WRONLY),MPI_INFO_NULL, &
+     CALL MPI_File_open(this%process_grid%within_slice_comm, file_name, &
+          & IOR(MPI_MODE_CREATE,MPI_MODE_WRONLY), MPI_INFO_NULL, &
           & mpi_file_handler,ierr)
-     CALL MPI_File_set_size(mpi_file_handler,zero_size,ierr)
+     CALL MPI_File_set_size(mpi_file_handler, zero_size, ierr)
+
      !! Write Header
+     header_offset = 0
+     CALL MPI_File_set_view(mpi_file_handler, header_offset, MPI_CHARACTER, &
+          & MPI_CHARACTER, "native", MPI_INFO_NULL, ierr)
      IF (this%process_grid%within_slice_rank .EQ. 0) THEN
-        header_offset = 0
-        CALL MPI_File_write_at(mpi_file_handler,header_offset,header_line1, &
+        CALL MPI_File_write(mpi_file_handler, header_line1, &
              & LEN(header_line1), MPI_CHARACTER, message_status, ierr)
-        header_offset = header_offset + LEN(header_line1)
-        CALL MPI_File_write_at(mpi_file_handler,header_offset,header_line2, &
+     END IF
+     header_offset = header_offset + LEN(header_line1)
+     CALL MPI_File_set_view(mpi_file_handler, header_offset, MPI_CHARACTER, &
+          & MPI_CHARACTER, "native", MPI_INFO_NULL, ierr)
+     IF (this%process_grid%within_slice_rank .EQ. 0) THEN
+        CALL MPI_File_write(mpi_file_handler, header_line2, &
              & LEN(header_line2), MPI_CHARACTER, message_status, ierr)
      END IF
+
      !! Write Local Data
-     CALL MPI_File_set_view(mpi_file_handler,write_offset,MPI_CHARACTER,&
-          & MPI_CHARACTER,"native",MPI_INFO_NULL,ierr)
-     CALL MPI_File_write(mpi_file_handler,write_buffer, &
-          & triplet_list_string_length,&
-          & MPI_CHARACTER,MPI_STATUS_IGNORE,ierr)
+     CALL MPI_File_set_view(mpi_file_handler, write_offset, MPI_CHARACTER, &
+          & MPI_CHARACTER, "native", MPI_INFO_NULL, ierr)
+     CALL MPI_File_write(mpi_file_handler, write_buffer, &
+          & triplet_list_string_length, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
 
      !! Cleanup
-     CALL MPI_File_close(mpi_file_handler,ierr)
+     CALL MPI_File_close(mpi_file_handler, ierr)
   END IF
-  CALL MPI_Barrier(this%process_grid%global_comm,ierr)
+  CALL MPI_Barrier(this%process_grid%global_comm, ierr)


### PR DESCRIPTION
This includes two fixes.

* On some versions of intel, the header wasn't being written properly using the write_at command. Switching to a file view setup (as is used for the entries of the matrix) things appear to work.

* Cleaned up the matrix output.