### PR TITLE
Fix compilation with ifort

### DIFF
--- a/Source/Fortran/MatrixMarketModule.F90
+++ b/Source/Fortran/MatrixMarketModule.F90
@@ -136,7 +136,7 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     END IF
 
     !! Combine
-    WRITE(outstring, '(A A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
+    WRITE(outstring, '(3A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
          & ADJUSTL(TRIM(temp3))
 
   END SUBROUTINE WriteMMSize
@@ -168,10 +168,10 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, '(A A A)') ADJUSTL(TRIM(temp1)), &
+       WRITE(outstring, '(3A)') ADJUSTL(TRIM(temp1)), &
             & ADJUSTL(TRIM(temp2)) // NEW_LINE('A')
     ELSE
-       WRITE(outstring, '(A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2))
+       WRITE(outstring, '(2A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2))
     END IF
   END SUBROUTINE WriteMMLine_ii
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -205,10 +205,10 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, '(A A A A)') ADJUSTL(TRIM(temp1)), &
+       WRITE(outstring, '(4A)') ADJUSTL(TRIM(temp1)), &
             & ADJUSTL(TRIM(temp2)), ADJUSTL(TRIM(temp3)) // NEW_LINE('A')
     ELSE
-       WRITE(outstring, '(A A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
+       WRITE(outstring, '(3A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
             & ADJUSTL(TRIM(temp3))
     END IF
   END SUBROUTINE WriteMMLine_iif
@@ -247,11 +247,11 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, '(A A A A A)') ADJUSTL(TRIM(temp1)), &
+       WRITE(outstring, '(5A)') ADJUSTL(TRIM(temp1)), &
             & ADJUSTL(TRIM(temp2)), ADJUSTL(TRIM(temp3)), &
             & ADJUSTL(TRIM(temp4)) // NEW_LINE('A')
     ELSE
-       WRITE(outstring, '(A A A A)') ADJUSTL(TRIM(temp1)), &
+       WRITE(outstring, '(4A)') ADJUSTL(TRIM(temp1)), &
             & ADJUSTL(TRIM(temp2)), ADJUSTL(TRIM(temp3)), ADJUSTL(TRIM(temp4))
     END IF
   END SUBROUTINE WriteMMLine_iiff
@@ -280,7 +280,7 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, '(A A)') ADJUSTL(TRIM(temp1)) // NEW_LINE('A')
+       WRITE(outstring, '(2A)') ADJUSTL(TRIM(temp1)) // NEW_LINE('A')
     ELSE
        WRITE(outstring, '(A)') ADJUSTL(TRIM(temp1))
     END IF
@@ -313,10 +313,10 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     !! Combine
     IF (add_newline) THEN
-       WRITE(outstring, '(A A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)) &
+       WRITE(outstring, '(3A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)) &
             & // NEW_LINE('A')
     ELSE
-       WRITE(outstring, '(A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2))
+       WRITE(outstring, '(2A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2))
     END IF
   END SUBROUTINE WriteMMLine_ff
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
Nothing but changing all WRITE(xxx, '(A A)') ... to WRITE(xxx, '(2A)') ...

Otherwise I got the following error message with ifort (version 19):

```
[14/39] Building Fortran object Source/Fortran/CMakeFiles/NTPoly.dir/SolverParametersModule.F90.o
FAILED: Source/Fortran/CMakeFiles/NTPoly.dir/MatrixMarketModule.F90.o include/matrixmarketmodule.mod 
/opt/intel/impi/2018.2.199/bin64/mpiifort  -I../Source/Fortran -O3 -fpp -module include -c Source/Fortran/CMakeFiles/NTPoly.dir/MatrixMarketModule.F90-pp.f90 -o Source/Fortran/CMakeFiles/NTPoly.dir/MatrixMarketModule.F90.o
Source/Fortran/CMakeFiles/NTPoly.dir/../Source/Fortran/MatrixMarketModule.F90(139): error #7421: A constant or general expression must appear in a format list in this context.   [AAA]
    WRITE(outstring, '(A A A)') ADJUSTL(TRIM(temp1)), ADJUSTL(TRIM(temp2)), &
-----------------------^
```