### PR TITLE
Optimizations related to matrix conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,4 @@ jobs:
         TESTEXAMPLES:     ${{ matrix.testexamples }}
     - name:               lint
       run:                |
-        cd UnitTests
-        bash lint.sh
-        cd ../
+        bash UnitTests/lint.sh

--- a/Source/Fortran/MatrixReduceModule.F90
+++ b/Source/Fortran/MatrixReduceModule.F90
@@ -41,10 +41,12 @@ MODULE MatrixReduceModule
   PUBLIC :: ReduceAndComposeMatrixSizes
   PUBLIC :: ReduceAndComposeMatrixData
   PUBLIC :: ReduceAndComposeMatrixCleanup
+  PUBLIC :: ReduceAndComposeMatrix
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   PUBLIC :: ReduceAndSumMatrixSizes
   PUBLIC :: ReduceAndSumMatrixData
   PUBLIC :: ReduceAndSumMatrixCleanup
+  PUBLIC :: ReduceAndSumMatrix
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   PUBLIC :: TestReduceSizeRequest
   PUBLIC :: TestReduceInnerRequest
@@ -62,6 +64,10 @@ MODULE MatrixReduceModule
      MODULE PROCEDURE ReduceAndComposeMatrixCleanup_lsr
      MODULE PROCEDURE ReduceAndComposeMatrixCleanup_lsc
   END INTERFACE
+  INTERFACE ReduceAndComposeMatrix
+     MODULE PROCEDURE ReduceAndComposeMatrix_lsr
+     MODULE PROCEDURE ReduceAndComposeMatrix_lsc
+  END INTERFACE
   INTERFACE ReduceAndSumMatrixSizes
      MODULE PROCEDURE ReduceAndSumMatrixSizes_lsr
      MODULE PROCEDURE ReduceAndSumMatrixSizes_lsc
@@ -73,6 +79,10 @@ MODULE MatrixReduceModule
   INTERFACE ReduceAndSumMatrixCleanup
      MODULE PROCEDURE ReduceAndSumMatrixCleanup_lsr
      MODULE PROCEDURE ReduceAndSumMatrixCleanup_lsc
+  END INTERFACE
+  INTERFACE ReduceAndSumMatrix
+     MODULE PROCEDURE ReduceAndSumMatrix_lsr
+     MODULE PROCEDURE ReduceAndSumMatrix_lsc
   END INTERFACE
 CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> The first routine to call, gathers the sizes of the data to be sent.
@@ -250,6 +260,38 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   END SUBROUTINE ReduceAndComposeMatrixCleanup_lsc
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !> Reduce and sum the matrices in one step. If you use this method, you
+  !> lose the opportunity for overlapping communication.
+  SUBROUTINE ReduceAndComposeMatrix_lsr(matrix, gathered_matrix, comm)
+    !> The matrix to send.
+    TYPE(Matrix_lsr), INTENT(IN)    :: matrix
+    !> The matrix we are gathering.
+    TYPE(Matrix_lsr), INTENT(INOUT) :: gathered_matrix
+    !> The communicator to send along.
+    INTEGER, INTENT(INOUT)              :: comm
+    !! Local Variables
+    TYPE(ReduceHelper_t) :: helper
+
+    INCLUDE "comm_includes/ReduceAndComposeMatrix.f90"
+
+  END SUBROUTINE ReduceAndComposeMatrix_lsr
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !> Reduce and sum the matrices in one step. If you use this method, you
+  !> lose the opportunity for overlapping communication.
+  SUBROUTINE ReduceAndComposeMatrix_lsc(matrix, gathered_matrix, comm)
+    !> The matrix to send.
+    TYPE(Matrix_lsc), INTENT(IN)    :: matrix
+    !> The matrix we are gathering.
+    TYPE(Matrix_lsc), INTENT(INOUT) :: gathered_matrix
+    !> The communicator to send along.
+    INTEGER, INTENT(INOUT)              :: comm
+    !! Local Variables
+    TYPE(ReduceHelper_t) :: helper
+
+    INCLUDE "comm_includes/ReduceAndComposeMatrix.f90"
+
+  END SUBROUTINE ReduceAndComposeMatrix_lsc
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> The first routine to call, gathers the sizes of the data to be sent.
   SUBROUTINE ReduceAndSumMatrixSizes_lsr(matrix, communicator,  &
        & gathered_matrix, helper)
@@ -425,6 +467,40 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     END IF
 #endif
   END SUBROUTINE ReduceAndSumMatrixCleanup_lsc
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !> Reduce and sum the matrices in one step. If you use this method, you
+  !> lose the opportunity for overlapping communication.
+  SUBROUTINE ReduceAndSumMatrix_lsr(matrix, gathered_matrix, threshold, comm)
+    !> The matrix to send.
+    TYPE(Matrix_lsr), INTENT(IN)        :: matrix
+    !> The gathered_matrix the matrix being gathered.
+    TYPE(Matrix_lsr), INTENT(INOUT)     :: gathered_matrix
+    !> The threshold the threshold for flushing values.
+    REAL(NTREAL), INTENT(IN)            :: threshold
+    !> The communicator to send along.
+    INTEGER, INTENT(INOUT)              :: comm
+    !! Local Data
+    TYPE(ReduceHelper_t) :: helper
+
+    INCLUDE "comm_includes/ReduceAndSumMatrix.f90"
+  END SUBROUTINE ReduceAndSumMatrix_lsr
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !> Reduce and sum the matrices in one step. If you use this method, you
+  !> lose the opportunity for overlapping communication.
+  SUBROUTINE ReduceAndSumMatrix_lsc(matrix, gathered_matrix, threshold, comm)
+    !> The matrix to send.
+    TYPE(Matrix_lsc), INTENT(IN)        :: matrix
+    !> The threshold the threshold for flushing values.
+    TYPE(Matrix_lsc), INTENT(INOUT)     :: gathered_matrix
+    !> The threshold the threshold for flushing values.
+    REAL(NTREAL), INTENT(IN)            :: threshold
+    !> The communicator to send along.
+    INTEGER, INTENT(INOUT)              :: comm
+    !! Local Data
+    TYPE(ReduceHelper_t) :: helper
+
+    INCLUDE "comm_includes/ReduceAndSumMatrix.f90"
+  END SUBROUTINE ReduceAndSumMatrix_lsc
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> Test if a request for the size of the matrices is complete.
   FUNCTION TestReduceSizeRequest(helper) RESULT(request_completed)

--- a/Source/Fortran/PSMatrixModule.F90
+++ b/Source/Fortran/PSMatrixModule.F90
@@ -773,15 +773,21 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> This routine fills in a matrix based on local triplet lists. Each process
   !> should pass in triplet lists with global coordinates. It does not matter
   !> where each triplet is stored, as long as global coordinates are given.
-  SUBROUTINE FillMatrixFromTripletList_psr(this,triplet_list,preduplicated_in)
+  !> However, if you explicitly set prepartitioned_in to True, all data must be
+  !> on the correct process. In that case, there is no communication required.
+  SUBROUTINE FillMatrixFromTripletList_psr(this, triplet_list, &
+       & preduplicated_in, prepartitioned_in)
     !> The matrix to fill.
     TYPE(Matrix_ps) :: this
     !> The triplet list of values.
     TYPE(TripletList_r) :: triplet_list
     !> If lists are preduplicated across slices set this to true.
     LOGICAL, INTENT(IN), OPTIONAL :: preduplicated_in
+    !> If all lists only contain local matrix elements set this to true.
+    LOGICAL, INTENT(IN), OPTIONAL :: prepartitioned_in
     !! Local Data
     TYPE(Matrix_ps) :: temp_matrix
+    TYPE(TripletList_r) :: shifted
     TYPE(TripletList_r) :: sorted_triplet_list
     TYPE(Matrix_lsr) :: local_matrix
     TYPE(Matrix_lsr) :: gathered_matrix
@@ -790,6 +796,9 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     TYPE(ReduceHelper_t) :: gather_helper
     REAL(NTREAL), PARAMETER :: threshold = 0.0_NTREAL
     LOGICAL :: preduplicated
+    LOGICAL :: prepartitioned
+    INTEGER :: local_column, local_row
+    INTEGER :: II
 
     IF (this%is_complex) THEN
        CALL ConvertMatrixToReal(this, temp_matrix)
@@ -803,14 +812,20 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> This routine fills in a matrix based on local triplet lists. Each process
   !> should pass in triplet lists with global coordinates. It does not matter
   !> where each triplet is stored, as long as global coordinates are given.
-  SUBROUTINE FillMatrixFromTripletList_psc(this,triplet_list,preduplicated_in)
+  !> However, if you explicitly set prepartitioned_in to True, all data must be
+  !> on the correct process. In that case, there is no communication required.
+  SUBROUTINE FillMatrixFromTripletList_psc(this, triplet_list, &
+       & preduplicated_in, prepartitioned_in)
     !> The matrix to fill.
     TYPE(Matrix_ps) :: this
     !> The triplet list of values.
     TYPE(TripletList_c) :: triplet_list
     !> If lists are preduplicated across slices set this to true.
     LOGICAL, INTENT(IN), OPTIONAL :: preduplicated_in
+    !> If all lists only contain local matrix elements set this to true.
+    LOGICAL, INTENT(IN), OPTIONAL :: prepartitioned_in
     !! Local Data
+    TYPE(TripletList_c) :: shifted
     TYPE(TripletList_c) :: sorted_triplet_list
     TYPE(Matrix_lsc) :: local_matrix
     TYPE(Matrix_lsc) :: gathered_matrix
@@ -820,6 +835,9 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     TYPE(ReduceHelper_t) :: gather_helper
     REAL(NTREAL), PARAMETER :: threshold = 0.0_NTREAL
     LOGICAL :: preduplicated
+    LOGICAL :: prepartitioned
+    INTEGER :: local_column, local_row
+    INTEGER :: II
 
     IF (.NOT. this%is_complex) THEN
        CALL ConvertMatrixToComplex(this, temp_matrix)

--- a/Source/Fortran/PSMatrixModule.F90
+++ b/Source/Fortran/PSMatrixModule.F90
@@ -9,11 +9,8 @@ MODULE PSMatrixModule
        & WriteListElement, WriteHeader
   USE MatrixMarketModule, ONLY : ParseMMHeader, MM_COMPLEX, WriteMMSize, &
        & WriteMMLine, MAX_LINE_LENGTH
-  USE MatrixReduceModule, ONLY : ReduceHelper_t, ReduceAndComposeMatrixSizes, &
-       & ReduceAndComposeMatrixData, ReduceAndComposeMatrixCleanup, &
-       & ReduceANdSumMatrixSizes, ReduceAndSumMatrixData, &
-       & ReduceAndSumMatrixCleanup, TestReduceSizeRequest, &
-       & TestReduceInnerRequest, TestReduceDataRequest
+  USE MatrixReduceModule, ONLY : ReduceHelper_t, ReduceAndComposeMatrix, &
+       & ReduceAndSumMatrix
   USE PermutationModule, ONLY : Permutation_t, ConstructDefaultPermutation
   USE ProcessGridModule, ONLY : ProcessGrid_t, global_grid, IsRoot, &
        & SplitProcessGrid
@@ -793,12 +790,9 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     TYPE(Matrix_lsr) :: gathered_matrix
     !! Local Data
     TYPE(Permutation_t) :: basic_permutation
-    TYPE(ReduceHelper_t) :: gather_helper
     REAL(NTREAL), PARAMETER :: threshold = 0.0_NTREAL
     LOGICAL :: preduplicated
     LOGICAL :: prepartitioned
-    INTEGER :: local_column, local_row
-    INTEGER :: II
 
     IF (this%is_complex) THEN
        CALL ConvertMatrixToReal(this, temp_matrix)
@@ -832,12 +826,9 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !! Local Data
     TYPE(Matrix_ps) :: temp_matrix
     TYPE(Permutation_t) :: basic_permutation
-    TYPE(ReduceHelper_t) :: gather_helper
     REAL(NTREAL), PARAMETER :: threshold = 0.0_NTREAL
     LOGICAL :: preduplicated
     LOGICAL :: prepartitioned
-    INTEGER :: local_column, local_row
-    INTEGER :: II
 
     IF (.NOT. this%is_complex) THEN
        CALL ConvertMatrixToComplex(this, temp_matrix)
@@ -867,9 +858,6 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     TYPE(Matrix_ps), INTENT(INOUT) :: this
     !! Local Data
     TYPE(TripletList_r) :: triplet_list
-    TYPE(TripletList_r) :: unsorted_triplet_list
-    TYPE(TripletList_r) :: sorted_triplet_list
-    TYPE(Matrix_lsr) :: local_matrix
 
     INCLUDE "distributed_includes/FillMatrixIdentity.f90"
 
@@ -881,9 +869,6 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     TYPE(Matrix_ps), INTENT(INOUT) :: this
     !! Local Data
     TYPE(TripletList_c) :: triplet_list
-    TYPE(TripletList_c) :: unsorted_triplet_list
-    TYPE(TripletList_c) :: sorted_triplet_list
-    TYPE(Matrix_lsc) :: local_matrix
 
     INCLUDE "distributed_includes/FillMatrixIdentity.f90"
 
@@ -926,9 +911,6 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     LOGICAL, INTENT(IN) :: rows
     !! Local Data
     TYPE(TripletList_r) :: triplet_list
-    TYPE(TripletList_r) :: unsorted_triplet_list
-    TYPE(TripletList_r) :: sorted_triplet_list
-    TYPE(Matrix_lsr) :: local_matrix
 
     INCLUDE "distributed_includes/FillMatrixPermutation.f90"
 
@@ -944,9 +926,6 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     LOGICAL, INTENT(IN) :: rows
     !! Local Data
     TYPE(TripletList_c) :: triplet_list
-    TYPE(TripletList_c) :: unsorted_triplet_list
-    TYPE(TripletList_c) :: sorted_triplet_list
-    TYPE(Matrix_lsc) :: local_matrix
 
     INCLUDE "distributed_includes/FillMatrixPermutation.f90"
 

--- a/Source/Fortran/TripletListModule.F90
+++ b/Source/Fortran/TripletListModule.F90
@@ -40,7 +40,6 @@ MODULE TripletListModule
   PUBLIC :: RedistributeTripletLists
   PUBLIC :: ShiftTripletList
   PUBLIC :: ConvertTripletListType
-  PUBLIC :: CopyTripletList
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   INTERFACE TripletList_r
      MODULE PROCEDURE ConstructTripletList_r

--- a/Source/Fortran/TripletListModule.F90
+++ b/Source/Fortran/TripletListModule.F90
@@ -40,6 +40,7 @@ MODULE TripletListModule
   PUBLIC :: RedistributeTripletLists
   PUBLIC :: ShiftTripletList
   PUBLIC :: ConvertTripletListType
+  PUBLIC :: CopyTripletList
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   INTERFACE TripletList_r
      MODULE PROCEDURE ConstructTripletList_r

--- a/Source/Fortran/comm_includes/ReduceAndComposeMatrix.f90
+++ b/Source/Fortran/comm_includes/ReduceAndComposeMatrix.f90
@@ -1,0 +1,11 @@
+  CALL ReduceAndComposeMatrixSizes(matrix, comm, gathered_matrix, helper)
+  DO WHILE(.NOT. TestReduceSizeRequest(helper))
+  END DO
+
+  CALL ReduceAndComposeMatrixData(matrix, comm, gathered_matrix, helper)
+  DO WHILE(.NOT. TestReduceInnerRequest(helper))
+  END DO
+  DO WHILE(.NOT. TestReduceDataRequest(helper))
+  END DO
+
+  CALL ReduceAndComposeMatrixCleanup(matrix, gathered_matrix, helper)

--- a/Source/Fortran/comm_includes/ReduceAndSumMatrix.f90
+++ b/Source/Fortran/comm_includes/ReduceAndSumMatrix.f90
@@ -1,0 +1,11 @@
+  CALL ReduceAndSumMatrixSizes(matrix, comm, gathered_matrix, helper)
+  DO WHILE(.NOT. TestReduceSizeRequest(helper))
+  END DO
+
+  CALL ReduceAndSumMatrixData(matrix, gathered_matrix, comm, helper)
+  DO WHILE(.NOT. TestReduceInnerRequest(helper))
+  END DO
+  DO WHILE(.NOT. TestReduceDataRequest(helper))
+  END DO
+  
+  CALL ReduceAndSumMatrixCleanup(matrix, gathered_matrix, threshold, helper)

--- a/Source/Fortran/distributed_includes/FillMatrixFromTripletList.f90
+++ b/Source/Fortran/distributed_includes/FillMatrixFromTripletList.f90
@@ -1,43 +1,68 @@
+  !! Optional Parameteres
   IF (.NOT. PRESENT(preduplicated_in)) THEN
      preduplicated = .FALSE.
   ELSE
      preduplicated = preduplicated_in
   END IF
 
-  CALL StartTimer("FillFromTriplet")
-  !! First we redistribute the triplet list to get all the local data
-  !! on the correct process.
-  CALL ConstructDefaultPermutation(basic_permutation, &
-       & this%logical_matrix_dimension)
-  CALL RedistributeData(this,basic_permutation%index_lookup, &
-       & basic_permutation%reverse_index_lookup, triplet_list, &
-       & sorted_triplet_list)
-
-  !! Now we can just construct a local matrix.
-  CALL ConstructMatrixFromTripletList(local_matrix, sorted_triplet_list, &
-       & this%local_rows, this%local_columns)
-  !! And reduce over the Z dimension. This can be accomplished by
-  !! summing up.
-  IF (.NOT. preduplicated .AND. &
-       & .NOT. this%process_grid%num_process_slices .EQ. 1) THEN
-     CALL ReduceAndSumMatrixSizes(local_matrix, &
-          & this%process_grid%between_slice_comm, gathered_matrix, &
-          & gather_helper)
-     DO WHILE(.NOT. TestReduceSizeRequest(gather_helper))
-     END DO
-     CALL ReduceAndSumMatrixData(local_matrix, gathered_matrix, &
-          & this%process_grid%between_slice_comm, gather_helper)
-     DO WHILE(.NOT. TestReduceInnerRequest(gather_helper))
-     END DO
-     DO WHILE(.NOT. TestReduceDataRequest(gather_helper))
-     END DO
-     CALL ReduceAndSumMatrixCleanup(local_matrix, gathered_matrix, threshold, &
-          & gather_helper)
-     CALL SplitMatrixToLocalBlocks(this, gathered_matrix)
+  IF (.NOT. PRESENT(prepartitioned_in)) THEN
+     prepartitioned = .FALSE.
   ELSE
-     CALL SplitMatrixToLocalBlocks(this, local_matrix)
+     prepartitioned = prepartitioned_in
   END IF
-  CALL StopTimer("FillFromTriplet")
 
+  CALL StartTimer("FillFromTriplet")
+
+  IF (prepartitioned) THEN
+     !! Shift and sort the local entries.
+     CALL ConstructTripletList(shifted, triplet_list%CurrentSize)
+     shifted%data(:triplet_list%CurrentSize) = triplet_list%data(:triplet_list%CurrentSize)
+     DO II = 1, shifted%CurrentSize
+        local_column = shifted%data(II)%index_column - this%start_column + 1
+        local_row = shifted%data(II)%index_row - this%start_row + 1
+        shifted%data(II)%index_column = local_column
+        shifted%data(II)%index_row = local_row
+     END DO
+     CALL SortTripletList(shifted, this%local_columns, &
+          & this%local_rows, sorted_triplet_list)
+     !! Build
+     CALL ConstructMatrixFromTripletList(local_matrix, sorted_triplet_list, &
+          & this%local_rows, this%local_columns)
+     CALL SplitMatrixToLocalBlocks(this, local_matrix)
+  ELSE
+     !! First we redistribute the triplet list to get all the local data
+     !! on the correct process.
+     CALL ConstructDefaultPermutation(basic_permutation, &
+          & this%logical_matrix_dimension)
+     CALL RedistributeData(this,basic_permutation%index_lookup, &
+          & basic_permutation%reverse_index_lookup, triplet_list, &
+          & sorted_triplet_list)
+
+     !! Now we can just construct a local matrix.
+     CALL ConstructMatrixFromTripletList(local_matrix, sorted_triplet_list, &
+          & this%local_rows, this%local_columns)
+     !! And reduce over the Z dimension. This can be accomplished by
+     !! summing up.
+     IF (.NOT. preduplicated .AND. &
+          & .NOT. this%process_grid%num_process_slices .EQ. 1) THEN
+        CALL ReduceAndSumMatrixSizes(local_matrix, &
+             & this%process_grid%between_slice_comm, gathered_matrix, &
+             & gather_helper)
+        DO WHILE(.NOT. TestReduceSizeRequest(gather_helper))
+        END DO
+        CALL ReduceAndSumMatrixData(local_matrix, gathered_matrix, &
+             & this%process_grid%between_slice_comm, gather_helper)
+        DO WHILE(.NOT. TestReduceInnerRequest(gather_helper))
+        END DO
+        DO WHILE(.NOT. TestReduceDataRequest(gather_helper))
+        END DO
+        CALL ReduceAndSumMatrixCleanup(local_matrix, gathered_matrix, &
+             & threshold, gather_helper)
+        CALL SplitMatrixToLocalBlocks(this, gathered_matrix)
+     ELSE
+        CALL SplitMatrixToLocalBlocks(this, local_matrix)
+     END IF
+     CALL StopTimer("FillFromTriplet")
+  END IF
   CALL DestructMatrix(local_matrix)
   CALL DestructTripletList(sorted_triplet_list)

--- a/Source/Fortran/distributed_includes/FillMatrixIdentity.f90
+++ b/Source/Fortran/distributed_includes/FillMatrixIdentity.f90
@@ -12,24 +12,15 @@
         IF (j + this%start_row - 1 .EQ. i + this%start_column - 1 .AND. &
              & j+this%start_row-1 .LE. this%actual_matrix_dimension) THEN
            total_values = total_values + 1
-           triplet_list%data(total_values)%index_column = i
-           triplet_list%data(total_values)%index_row = j
+           triplet_list%data(total_values)%index_column = i + this%start_column - 1 
+           triplet_list%data(total_values)%index_row = j + this%start_row - 1
            triplet_list%data(total_values)%point_value = 1.0
         END IF
      END DO column_iter
   END DO row_iter
+  triplet_list%CurrentSize = total_values
 
   !! Finish constructing
-  CALL ConstructTripletList(unsorted_triplet_list, total_values)
-  unsorted_triplet_list%data = triplet_list%data(:total_values)
-  CALL SortTripletList(unsorted_triplet_list,this%local_columns,&
-       & this%local_rows, sorted_triplet_list)
-  CALL ConstructMatrixFromTripletList(local_matrix, sorted_triplet_list, &
-       & this%local_rows, this%local_columns)
+  CALL FillMatrixFromTripletList(this, unsorted_triplet_list, prepartitioned_in=.TRUE.)
 
-  CALL SplitMatrixToLocalBlocks(this, local_matrix)
-
-  CALL DestructMatrix(local_matrix)
   CALL DestructTripletList(triplet_list)
-  CALL DestructTripletList(unsorted_triplet_list)
-  CALL DestructTripletList(sorted_triplet_list)

--- a/Source/Fortran/distributed_includes/FillMatrixIdentity.f90
+++ b/Source/Fortran/distributed_includes/FillMatrixIdentity.f90
@@ -1,26 +1,26 @@
   !! Local Data
-  INTEGER :: i, j
-  INTEGER :: total_values
+  INTEGER :: II, JJ
+  INTEGER :: total
 
   !! There can't be more than one entry per row
   CALL ConstructTripletList(triplet_list, this%local_rows)
 
-  total_values = 0
+  total = 0
   !! Find local identity values
-  row_iter: DO j = 1, this%local_rows
-     column_iter: DO i = 1, this%local_columns
-        IF (j + this%start_row - 1 .EQ. i + this%start_column - 1 .AND. &
-             & j+this%start_row-1 .LE. this%actual_matrix_dimension) THEN
-           total_values = total_values + 1
-           triplet_list%data(total_values)%index_column = i + this%start_column - 1 
-           triplet_list%data(total_values)%index_row = j + this%start_row - 1
-           triplet_list%data(total_values)%point_value = 1.0
+  DO JJ = this%start_row, this%end_row - 1
+     DO II = this%start_column, this%end_column - 1
+        IF (JJ .EQ. II .AND. JJ .LE. this%actual_matrix_dimension) THEN
+           total = total + 1
+           triplet_list%data(total)%index_column = II
+           triplet_list%data(total)%index_row = JJ
+           triplet_list%data(total)%point_value = 1.0
         END IF
-     END DO column_iter
-  END DO row_iter
-  triplet_list%CurrentSize = total_values
+     END DO
+  END DO
+  triplet_list%CurrentSize = total
 
   !! Finish constructing
-  CALL FillMatrixFromTripletList(this, unsorted_triplet_list, prepartitioned_in=.TRUE.)
+  CALL FillMatrixFromTripletList(this, triplet_list, prepartitioned_in=.TRUE.)
 
+  !! Cleanup
   CALL DestructTripletList(triplet_list)

--- a/Source/Fortran/distributed_includes/FillMatrixPermutation.f90
+++ b/Source/Fortran/distributed_includes/FillMatrixPermutation.f90
@@ -1,49 +1,36 @@
   !! Local Data
-  INTEGER :: total_values
-  INTEGER :: counter
-  INTEGER :: local_row, local_column
+  INTEGER :: total
+  INTEGER :: II
 
   !! Build Local Triplet List
   !! There can't be more than one entry per row
   CALL ConstructTripletList(triplet_list, this%local_rows)
-  total_values = 0
+  total = 0
   IF (rows) THEN
-     DO counter=this%start_row,this%end_row-1
-        IF (permutation_vector(counter) .GE. this%start_column .AND. &
-             & permutation_vector(counter) .LT. this%end_column) THEN
-           total_values = total_values + 1
-           local_column = permutation_vector(counter) - this%start_column + 1
-           local_row = counter - this%start_row + 1
-           triplet_list%data(total_values)%index_column = local_column
-           triplet_list%data(total_values)%index_row = local_row
-           triplet_list%data(total_values)%point_value = 1.0
+     DO II=this%start_row,this%end_row-1
+        IF (permutation_vector(II) .GE. this%start_column .AND. &
+             & permutation_vector(II) .LT. this%end_column) THEN
+           total = total + 1
+           triplet_list%data(total)%index_column = permutation_vector(II)
+           triplet_list%data(total)%index_row = II
+           triplet_list%data(total)%point_value = 1.0
         END IF
      END DO
   ELSE
-     DO counter=this%start_column,this%end_column-1
-        IF (permutation_vector(counter) .GE. this%start_row .AND. &
-             & permutation_vector(counter) .LT. this%end_row) THEN
-           total_values = total_values + 1
-           local_column = counter - this%start_column + 1
-           local_row = permutation_vector(counter) - this%start_row + 1
-           triplet_list%data(total_values)%index_column = local_column
-           triplet_list%data(total_values)%index_row = local_row
-           triplet_list%data(total_values)%point_value = 1.0
+     DO II=this%start_column,this%end_column-1
+        IF (permutation_vector(II) .GE. this%start_row .AND. &
+             & permutation_vector(II) .LT. this%end_row) THEN
+           total = total + 1
+           triplet_list%data(total)%index_column = II
+           triplet_list%data(total)%index_row = permutation_vector(II)
+           triplet_list%data(total)%point_value = 1.0
         END IF
      END DO
   END IF
+  triplet_list%CurrentSize = total
 
   !! Finish constructing
-  CALL ConstructTripletList(unsorted_triplet_list, total_values)
-  unsorted_triplet_list%data = triplet_list%data(:total_values)
-  CALL SortTripletList(unsorted_triplet_list, this%local_columns, &
-       & this%local_rows, sorted_triplet_list)
-  CALL ConstructMatrixFromTripletList(local_matrix, sorted_triplet_list, &
-       & this%local_rows, this%local_columns)
+  CALL FillMatrixFromTripletList(this, triplet_list, prepartitioned_in=.TRUE.)
 
-  CALL SplitMatrixToLocalBlocks(this, local_matrix)
-
-  CALL DestructMatrix(local_matrix)
+  !! Cleanup
   CALL DestructTripletList(triplet_list)
-  CALL DestructTripletList(unsorted_triplet_list)
-  CALL DestructTripletList(sorted_triplet_list)

--- a/Source/Fortran/distributed_includes/GatherMatrixToAll.f90
+++ b/Source/Fortran/distributed_includes/GatherMatrixToAll.f90
@@ -1,37 +1,15 @@
-  !! Local Data
-  TYPE(ReduceHelper_t) :: row_helper
-  TYPE(ReduceHelper_t) :: column_helper
 
   CALL MergeMatrixLocalBlocks(this, local)
 
   !! Merge Columns
   CALL TransposeMatrix(local, localT)
-  CALL ReduceAndComposeMatrixSizes(localT, this%process_grid%column_comm, &
-       & merged_columns, column_helper)
-  DO WHILE(.NOT. TestReduceSizeRequest(column_helper))
-  END DO
-  CALL ReduceAndComposeMatrixData(localT, this%process_grid%column_comm, &
-       & merged_columns, column_helper)
-  DO WHILE(.NOT. TestReduceInnerRequest(column_helper))
-  END DO
-  DO WHILE(.NOT. TestReduceDataRequest(column_helper))
-  END DO
-  CALL ReduceAndComposeMatrixCleanup(localT, merged_columns, column_helper)
+  CALL ReduceAndComposeMatrix(localT, merged_columns, &
+       & this%process_grid%column_comm)
 
   !! Merge Rows
   CALL TransposeMatrix(merged_columns, merged_columnsT)
-  CALL ReduceAndComposeMatrixSizes(merged_columnsT, &
-       & this%process_grid%row_comm, gathered, row_helper)
-  DO WHILE(.NOT. TestReduceSizeRequest(row_helper))
-  END DO
-  CALL ReduceAndComposeMatrixData(merged_columnsT, &
-       & this%process_grid%row_comm, gathered, row_helper)
-  DO WHILE(.NOT. TestReduceInnerRequest(row_helper))
-  END DO
-  DO WHILE(.NOT. TestReduceDataRequest(row_helper))
-  END DO
-  CALL ReduceAndComposeMatrixCleanup(merged_columnsT, gathered, &
-        & row_helper)
+  CALL ReduceAndComposeMatrix(merged_columnsT, gathered, &
+       & this%process_grid%row_comm)
 
   !! Remove the excess rows and columns that come from the logical size.
   CALL ConstructEmptyMatrix(local_mat, this%actual_matrix_dimension, &

--- a/Source/Fortran/distributed_includes/RedistributeData.f90
+++ b/Source/Fortran/distributed_includes/RedistributeData.f90
@@ -40,7 +40,6 @@
      CALL AppendToTripletList(send_triplet_lists(process_id+1), temp_triplet)
   END DO
 
-
   !! Actual Send
   CALL RedistributeTripletLists(send_triplet_lists, &
        & this%process_grid%within_slice_comm, gathered_list)

--- a/UnitTests/test_psmatrix.py
+++ b/UnitTests/test_psmatrix.py
@@ -429,7 +429,7 @@ class TestPSMatrix(unittest.TestCase):
 
     def test_snap(self):
         '''Test the sparsity pattern setting routine.'''
-        from scipy.sparse import dok_matrix, csr_matrix
+        from scipy.sparse import dok_matrix
 
         for param in self.parameters:
             matrix1 = param.create_matrix(self.complex)


### PR DESCRIPTION
This update includes a "prepartitioned" option for fill matrix from triplet list, so that if you have already prepartitioned the data you can skip the communication step.

I also modified the SNAP routine to remove any communication there. 