### PR TITLE
Simplified configuration on a Mac

### DIFF
--- a/Source/Swig/CMakeLists.txt
+++ b/Source/Swig/CMakeLists.txt
@@ -5,10 +5,6 @@ if(NOT DEFINED PYTHON_EXECUTABLE)
 endif()
 
 include(ConfigPython.cmake)
-if (APPLE)
-  get_py_lib()
-  message(STATUS "Using Python Library Path:" ${PYTHON_LIBRARIES})
-endif()
 get_py_include()
 message(STATUS "Using Python Include Path:" ${PYTHON_INCLUDE_PATH})
 
@@ -33,8 +29,11 @@ if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
 else()
    swig_add_library(NTPolySwig LANGUAGE python SOURCES ${Swigsrc})
 endif()
+if (APPLE)
+   set(APPLE_SUPRESS "-flat_namespace -undefined suppress")
+endif()
 swig_link_libraries(NTPolySwig NTPolyCPP NTPolyWrapper NTPoly
-                    ${PYTHON_LIBRARIES} ${TOOLCHAIN_LIBS})
+                    ${TOOLCHAIN_LIBS} ${APPLE_SUPRESS})
 set_target_properties(_NTPolySwig PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/python
   LIBRARY_OUTPUT_DIRECTORY  ${CMAKE_BINARY_DIR}/python

--- a/Source/Swig/ConfigPython.cmake
+++ b/Source/Swig/ConfigPython.cmake
@@ -6,15 +6,3 @@ macro(get_py_include)
       "from distutils.sysconfig import get_python_inc; print(get_python_inc())"
       OUTPUT_VARIABLE PYTHON_INCLUDE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
 endmacro()
-
-################################################################################
-# Determine Python Library Path
-macro(get_py_lib)
-  execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} -c
-"
-from distutils.sysconfig import get_python_lib
-path=get_python_lib(standard_lib=True)+\"/../../Python\"
-print(path)"
-    OUTPUT_VARIABLE PYTHON_LIBRARIES OUTPUT_STRIP_TRAILING_WHITESPACE)
-endmacro()


### PR DESCRIPTION
Previously, in order to get the python bindings to work on the mac, I had built a special configure script to search for the python libraries. Unfortunately, this was breaking things when I tried to use conda. I learned today that I could side step this issue using the linker flags `-flat_namespace -undefined suppress`. This will defer the search for python libraries until run time, at which point it works automatically.