### PR TITLE
Early exist condition for PM solver

### DIFF
--- a/Source/Fortran/DensityMatrixSolversModule.F90
+++ b/Source/Fortran/DensityMatrixSolversModule.F90
@@ -161,7 +161,12 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
        !! Compute Sigma
        CALL MatrixTrace(TempMat, trace_value)
        CALL DotMatrix(TempMat,X_k,trace_value2)
-       sigma_array(outer_counter) = trace_value2/trace_value
+       !! If we hit 0 exact convergence, avoid a division by zero.
+       IF (trace_value .LE. TINY(trace_value)) THEN
+          sigma_array(outer_counter) = 1.0_NTREAL
+       ELSE
+          sigma_array(outer_counter) = trace_value2/trace_value
+       END IF
 
        IF (sigma_array(outer_counter) .GT. 0.5_NTREAL) THEN
           a1 = 0.0_NTREAL


### PR DESCRIPTION
Fix for #163 

Basically, if we set all of the thresholding to zero, we can arrive at a situation where the change in the matrix at a given step is a matrix full of zeros. In the PM method, we divide by the trace of this update matrix, which will be exactly zero, which is of course a disaster. This modification will make sure this case never happens. Nonetheless, there is probably some remaining numerical instability in the PM method near convergence because you are dividing a small number by another small number.