### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
           - name:         ubuntu-standard
             os:           ubuntu-latest
             testos:       LINUX
-            maketest:     "make test"
+            maketest:     "ctest"
             testexamples: 1
             debug:        0
             noalligather: 0
@@ -27,7 +27,7 @@ jobs:
           - name:         ubuntu-nogather
             os:           ubuntu-latest
             testos:       LINUX
-            maketest:     "make test"
+            maketest:     "ctest"
             testexamples: 1
             debug:        0
             noalligather: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
       run:                |
         cd Build
         bash ../UnitTests/run_cmake.sh
-        # make VERBOSE=1
         ninja -v
         cd ../
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             debug:        1
             noalligather: 0
             mpich:        0
-      	    with:
+            with:
               name: ubuntu-debug
               path: Build
           - name:         ubuntu-nogather
@@ -38,7 +38,7 @@ jobs:
             debug:        0
             noalligather: 1
             mpich:        0
-      	    with:
+            with:
               name: ubuntu-nogather
               path: Build
           - name:         ubuntu-mpich
@@ -49,7 +49,7 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        1
-      	    with:
+            with:
               name: ubuntu-mpich
               path: Build
           - name:         mac
@@ -61,7 +61,7 @@ jobs:
             noalligather: 0
             mpich:        0
             lint:         1
-      	    with:
+            with:
               name: mac
               path: Build
     runs-on:              ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
             noalligather: 0
             mpich:        0
             with:
-	            name: ubuntu-standard
-	            path: Build
+              name: ubuntu-standard
+              path: Build
           - name:         ubuntu-debug
             os:           ubuntu-latest
             testos:       LINUX
@@ -28,8 +28,8 @@ jobs:
             noalligather: 0
             mpich:        0
       	    with:
-      	      name: ubuntu-debug
-      	      path: Build
+              name: ubuntu-debug
+              path: Build
           - name:         ubuntu-nogather
             os:           ubuntu-latest
             testos:       LINUX
@@ -39,8 +39,8 @@ jobs:
             noalligather: 1
             mpich:        0
       	    with:
-      	      name: ubuntu-nogather
-      	      path: Build
+              name: ubuntu-nogather
+              path: Build
           - name:         ubuntu-mpich
             os:           ubuntu-latest
             testos:       LINUX
@@ -50,8 +50,8 @@ jobs:
             noalligather: 0
             mpich:        1
       	    with:
-      	      name: ubuntu-mpich
-      	      path: Build
+              name: ubuntu-mpich
+              path: Build
           - name:         mac
             os:           macos-latest
             testos:       OSX
@@ -62,8 +62,8 @@ jobs:
             mpich:        0
             lint:         1
       	    with:
-      	      name: mac
-      	      path: Build
+              name: mac
+              path: Build
     runs-on:              ${{ matrix.os }}
     steps:
     - uses:               actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,6 @@ jobs:
         TESTOS:           ${{ matrix.testos }}
         DEBUG:            ${{ matrix.debug }}
         NOALLIGATHER:     ${{ matrix.noalligather }}
-      with:
-        name: build
-        path: Build
     - name:               regression tests
       run:                |
         cd Build
@@ -89,3 +86,9 @@ jobs:
       if:                 ${{ matrix.lint }}
       run:                |
         bash UnitTests/lint.sh
+    - name: upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v1
+      with:
+        name: build
+        path: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,41 +5,40 @@ jobs:
   build:
     strategy:
       matrix:
-        name:             [ubuntu-standard, ubuntu-debug, ubuntu-nogather,
-                           ubuntu-mpich, mac]
+        name:             [mac]
         include:
-          # - name:         ubuntu-standard
-          #   os:           ubuntu-latest
-          #   testos:       LINUX
-          #   maketest:     "make test"
-          #   testexamples: 1
-          #   debug:        0
-          #   noalligather: 0
-          #   mpich:        0
-          # - name:         ubuntu-debug
-          #   os:           ubuntu-latest
-          #   testos:       LINUX
-          #   maketest:     "ctest -R Regression111"
-          #   testexamples: 1
-          #   debug:        1
-          #   noalligather: 0
-          #   mpich:        0
-          # - name:         ubuntu-nogather
-          #   os:           ubuntu-latest
-          #   testos:       LINUX
-          #   maketest:     "make test"
-          #   testexamples: 1
-          #   debug:        0
-          #   noalligather: 1
-          #   mpich:        0
-          # - name:         ubuntu-mpich
-          #   os:           ubuntu-latest
-          #   testos:       LINUX
-          #   maketest:     "ctest -R Regression211"
-          #   testexamples: 0
-          #   debug:        0
-          #   noalligather: 0
-          #   mpich:        1
+          - name:         ubuntu-standard
+            os:           ubuntu-latest
+            testos:       LINUX
+            maketest:     "make test"
+            testexamples: 1
+            debug:        0
+            noalligather: 0
+            mpich:        0
+          - name:         ubuntu-debug
+            os:           ubuntu-latest
+            testos:       LINUX
+            maketest:     "ctest -R Regression111"
+            testexamples: 1
+            debug:        1
+            noalligather: 0
+            mpich:        0
+          - name:         ubuntu-nogather
+            os:           ubuntu-latest
+            testos:       LINUX
+            maketest:     "make test"
+            testexamples: 1
+            debug:        0
+            noalligather: 1
+            mpich:        0
+          - name:         ubuntu-mpich
+            os:           ubuntu-latest
+            testos:       LINUX
+            maketest:     "ctest -R Regression211"
+            testexamples: 0
+            debug:        0
+            noalligather: 0
+            mpich:        1
           - name:         mac
             os:           macos-latest
             testos:       OSX

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        name:             [mac] #, ubuntu-standard, ubuntu-debug, ubuntu-nogather,
+        name:             [mac, ubuntu-mpich] #, ubuntu-standard, ubuntu-debug, ubuntu-nogather,
                            #ubuntu-mpich]
         include:
           # - name:         ubuntu-standard
@@ -32,14 +32,14 @@ jobs:
           #   debug:        0
           #   noalligather: 1
           #   mpich:        0
-          # - name:         ubuntu-mpich
-          #   os:           ubuntu-latest
-          #   testos:       LINUX
-          #   maketest:     "ctest -R Regression211"
-          #   testexamples: 0
-          #   debug:        0
-          #   noalligather: 0
-          #   mpich:        1
+          - name:         ubuntu-mpich
+            os:           ubuntu-latest
+            testos:       LINUX
+            maketest:     "ctest -R Regression211"
+            testexamples: 0
+            debug:        0
+            noalligather: 0
+            mpich:        1
           - name:         mac
             os:           macos-latest
             testos:       OSX

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,32 +5,33 @@ jobs:
   build:
     strategy:
       matrix:
-        name:             [mac, ubuntu-mpich] #, ubuntu-standard, ubuntu-debug, ubuntu-nogather,
+        name:             [mac, ubuntu-mpich, ubuntu-standard, ubuntu-debug,
+                           ubuntu-nogather]
         include:
-          # - name:         ubuntu-standard
-          #   os:           ubuntu-latest
-          #   testos:       LINUX
-          #   maketest:     "make test"
-          #   testexamples: 1
-          #   debug:        0
-          #   noalligather: 0
-          #   mpich:        0
-          # - name:         ubuntu-debug
-          #   os:           ubuntu-latest
-          #   testos:       LINUX
-          #   maketest:     "ctest -R Regression111"
-          #   testexamples: 1
-          #   debug:        1
-          #   noalligather: 0
-          #   mpich:        0
-          # - name:         ubuntu-nogather
-          #   os:           ubuntu-latest
-          #   testos:       LINUX
-          #   maketest:     "make test"
-          #   testexamples: 1
-          #   debug:        0
-          #   noalligather: 1
-          #   mpich:        0
+          - name:         ubuntu-standard
+            os:           ubuntu-latest
+            testos:       LINUX
+            maketest:     "make test"
+            testexamples: 1
+            debug:        0
+            noalligather: 0
+            mpich:        0
+          - name:         ubuntu-debug
+            os:           ubuntu-latest
+            testos:       LINUX
+            maketest:     "ctest -R Regression111"
+            testexamples: 1
+            debug:        1
+            noalligather: 0
+            mpich:        0
+          - name:         ubuntu-nogather
+            os:           ubuntu-latest
+            testos:       LINUX
+            maketest:     "make test"
+            testexamples: 1
+            debug:        0
+            noalligather: 1
+            mpich:        0
           - name:         ubuntu-mpich
             os:           ubuntu-latest
             testos:       LINUX

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           #   noalligather: 1
           #   mpich:        0
           - name:         ubuntu-mpich
-            os:           ubuntu-latest
+            os:           ubuntu-18.04
             testos:       LINUX
             maketest:     "ctest -R Regression211"
             testexamples: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       run:                |
         cd Build
         bash ../UnitTests/run_cmake.sh
-        make
+        make VERBOSE=1
         cd ../
       env:
         TESTOS:           ${{ matrix.testos }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        0
+	    with:
+	      name: ubuntu-standard
+	      path: Build
           - name:         ubuntu-debug
             os:           ubuntu-latest
             testos:       LINUX
@@ -24,6 +27,9 @@ jobs:
             debug:        1
             noalligather: 0
             mpich:        0
+	    with:
+	      name: ubuntu-debug
+	      path: Build
           - name:         ubuntu-nogather
             os:           ubuntu-latest
             testos:       LINUX
@@ -32,6 +38,9 @@ jobs:
             debug:        0
             noalligather: 1
             mpich:        0
+	    with:
+	      name: ubuntu-nogather
+	      path: Build
           - name:         ubuntu-mpich
             os:           ubuntu-latest
             testos:       LINUX
@@ -40,6 +49,9 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        1
+	    with:
+	      name: ubuntu-mpich
+	      path: Build
           - name:         mac
             os:           macos-latest
             testos:       OSX
@@ -49,6 +61,9 @@ jobs:
             noalligather: 0
             mpich:        0
             lint:         1
+	    with:
+	      name: mac
+	      path: Build
     runs-on:              ${{ matrix.os }}
     steps:
     - uses:               actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ jobs:
   build:
     strategy:
       matrix:
-        name:             [mac]
+        name:             [mac] #, ubuntu-standard, ubuntu-debug, ubuntu-nogather,
+                           #ubuntu-mpich]
         include:
           # - name:         ubuntu-standard
           #   os:           ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,38 +7,38 @@ jobs:
       matrix:
         name:             [mac]
         include:
-          - name:         ubuntu-standard
-            os:           ubuntu-latest
-            testos:       LINUX
-            maketest:     "make test"
-            testexamples: 1
-            debug:        0
-            noalligather: 0
-            mpich:        0
-          - name:         ubuntu-debug
-            os:           ubuntu-latest
-            testos:       LINUX
-            maketest:     "ctest -R Regression111"
-            testexamples: 1
-            debug:        1
-            noalligather: 0
-            mpich:        0
-          - name:         ubuntu-nogather
-            os:           ubuntu-latest
-            testos:       LINUX
-            maketest:     "make test"
-            testexamples: 1
-            debug:        0
-            noalligather: 1
-            mpich:        0
-          - name:         ubuntu-mpich
-            os:           ubuntu-latest
-            testos:       LINUX
-            maketest:     "ctest -R Regression211"
-            testexamples: 0
-            debug:        0
-            noalligather: 0
-            mpich:        1
+          # - name:         ubuntu-standard
+          #   os:           ubuntu-latest
+          #   testos:       LINUX
+          #   maketest:     "make test"
+          #   testexamples: 1
+          #   debug:        0
+          #   noalligather: 0
+          #   mpich:        0
+          # - name:         ubuntu-debug
+          #   os:           ubuntu-latest
+          #   testos:       LINUX
+          #   maketest:     "ctest -R Regression111"
+          #   testexamples: 1
+          #   debug:        1
+          #   noalligather: 0
+          #   mpich:        0
+          # - name:         ubuntu-nogather
+          #   os:           ubuntu-latest
+          #   testos:       LINUX
+          #   maketest:     "make test"
+          #   testexamples: 1
+          #   debug:        0
+          #   noalligather: 1
+          #   mpich:        0
+          # - name:         ubuntu-mpich
+          #   os:           ubuntu-latest
+          #   testos:       LINUX
+          #   maketest:     "ctest -R Regression211"
+          #   testexamples: 0
+          #   debug:        0
+          #   noalligather: 0
+          #   mpich:        1
           - name:         mac
             os:           macos-latest
             testos:       OSX

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           #   noalligather: 1
           #   mpich:        0
           - name:         ubuntu-mpich
-            os:           ubuntu-18.04
+            os:           ubuntu-latest
             testos:       LINUX
             maketest:     "ctest -R Regression211"
             testexamples: 0
@@ -60,7 +60,8 @@ jobs:
       run:                |
         cd Build
         bash ../UnitTests/run_cmake.sh
-        make VERBOSE=1
+        # make VERBOSE=1
+        ninja -v
         cd ../
       env:
         TESTOS:           ${{ matrix.testos }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,38 +8,38 @@ jobs:
         name:             [ubuntu-standard, ubuntu-debug, ubuntu-nogather,
                            ubuntu-mpich, mac]
         include:
-          - name:         ubuntu-standard
-            os:           ubuntu-latest
-            testos:       LINUX
-            maketest:     "make test"
-            testexamples: 1
-            debug:        0
-            noalligather: 0
-            mpich:        0
-          - name:         ubuntu-debug
-            os:           ubuntu-latest
-            testos:       LINUX
-            maketest:     "ctest -R Regression111"
-            testexamples: 1
-            debug:        1
-            noalligather: 0
-            mpich:        0
-          - name:         ubuntu-nogather
-            os:           ubuntu-latest
-            testos:       LINUX
-            maketest:     "make test"
-            testexamples: 1
-            debug:        0
-            noalligather: 1
-            mpich:        0
-          - name:         ubuntu-mpich
-            os:           ubuntu-latest
-            testos:       LINUX
-            maketest:     "ctest -R Regression211"
-            testexamples: 0
-            debug:        0
-            noalligather: 0
-            mpich:        1
+          # - name:         ubuntu-standard
+          #   os:           ubuntu-latest
+          #   testos:       LINUX
+          #   maketest:     "make test"
+          #   testexamples: 1
+          #   debug:        0
+          #   noalligather: 0
+          #   mpich:        0
+          # - name:         ubuntu-debug
+          #   os:           ubuntu-latest
+          #   testos:       LINUX
+          #   maketest:     "ctest -R Regression111"
+          #   testexamples: 1
+          #   debug:        1
+          #   noalligather: 0
+          #   mpich:        0
+          # - name:         ubuntu-nogather
+          #   os:           ubuntu-latest
+          #   testos:       LINUX
+          #   maketest:     "make test"
+          #   testexamples: 1
+          #   debug:        0
+          #   noalligather: 1
+          #   mpich:        0
+          # - name:         ubuntu-mpich
+          #   os:           ubuntu-latest
+          #   testos:       LINUX
+          #   maketest:     "ctest -R Regression211"
+          #   testexamples: 0
+          #   debug:        0
+          #   noalligather: 0
+          #   mpich:        1
           - name:         mac
             os:           macos-latest
             testos:       OSX

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        0
-	    with:
-	      name: ubuntu-standard
-	      path: Build
+            with:
+	            name: ubuntu-standard
+	            path: Build
           - name:         ubuntu-debug
             os:           ubuntu-latest
             testos:       LINUX
@@ -27,9 +27,9 @@ jobs:
             debug:        1
             noalligather: 0
             mpich:        0
-	    with:
-	      name: ubuntu-debug
-	      path: Build
+      	    with:
+      	      name: ubuntu-debug
+      	      path: Build
           - name:         ubuntu-nogather
             os:           ubuntu-latest
             testos:       LINUX
@@ -38,9 +38,9 @@ jobs:
             debug:        0
             noalligather: 1
             mpich:        0
-	    with:
-	      name: ubuntu-nogather
-	      path: Build
+      	    with:
+      	      name: ubuntu-nogather
+      	      path: Build
           - name:         ubuntu-mpich
             os:           ubuntu-latest
             testos:       LINUX
@@ -49,9 +49,9 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        1
-	    with:
-	      name: ubuntu-mpich
-	      path: Build
+      	    with:
+      	      name: ubuntu-mpich
+      	      path: Build
           - name:         mac
             os:           macos-latest
             testos:       OSX
@@ -61,9 +61,9 @@ jobs:
             noalligather: 0
             mpich:        0
             lint:         1
-	    with:
-	      name: mac
-	      path: Build
+      	    with:
+      	      name: mac
+      	      path: Build
     runs-on:              ${{ matrix.os }}
     steps:
     - uses:               actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ jobs:
     strategy:
       matrix:
         name:             [mac, ubuntu-mpich] #, ubuntu-standard, ubuntu-debug, ubuntu-nogather,
-                           #ubuntu-mpich]
         include:
           # - name:         ubuntu-standard
           #   os:           ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        0
-            with:
-              name: ubuntu-standard
-              path: Build
           - name:         ubuntu-debug
             os:           ubuntu-latest
             testos:       LINUX
@@ -27,9 +24,6 @@ jobs:
             debug:        1
             noalligather: 0
             mpich:        0
-            with:
-              name: ubuntu-debug
-              path: Build
           - name:         ubuntu-nogather
             os:           ubuntu-latest
             testos:       LINUX
@@ -38,9 +32,6 @@ jobs:
             debug:        0
             noalligather: 1
             mpich:        0
-            with:
-              name: ubuntu-nogather
-              path: Build
           - name:         ubuntu-mpich
             os:           ubuntu-latest
             testos:       LINUX
@@ -49,9 +40,6 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        1
-            with:
-              name: ubuntu-mpich
-              path: Build
           - name:         mac
             os:           macos-latest
             testos:       OSX
@@ -61,9 +49,6 @@ jobs:
             noalligather: 0
             mpich:        0
             lint:         1
-            with:
-              name: mac
-              path: Build
     runs-on:              ${{ matrix.os }}
     steps:
     - uses:               actions/checkout@v1
@@ -82,6 +67,9 @@ jobs:
         TESTOS:           ${{ matrix.testos }}
         DEBUG:            ${{ matrix.debug }}
         NOALLIGATHER:     ${{ matrix.noalligather }}
+      with:
+        name: build
+        path: Build
     - name:               regression tests
       run:                |
         cd Build

--- a/Targets/Linux.cmake
+++ b/Targets/Linux.cmake
@@ -9,7 +9,7 @@ set(CMAKE_CXX_COMPILER mpicxx)
 set(TOOLCHAIN_LIBS "-lblas")
 
 # Release suggestions
-set(CXX_TOOLCHAINFLAGS_RELEASE "-O3 -fopenmp -lgomp")
+set(CXX_TOOLCHAINFLAGS_RELEASE "-O3 -fopenmp")
 set(F_TOOLCHAINFLAGS_RELEASE "-O3 -cpp -fopenmp")
 
 # Debug suggestions

--- a/Targets/Linux.cmake
+++ b/Targets/Linux.cmake
@@ -9,9 +9,9 @@ set(CMAKE_CXX_COMPILER mpicxx)
 set(TOOLCHAIN_LIBS "-lblas")
 
 # Release suggestions
-set(CXX_TOOLCHAINFLAGS_RELEASE "-O3 -openmp -lgomp")
-set(F_TOOLCHAINFLAGS_RELEASE "-O3 -cpp -openmp")
+set(CXX_TOOLCHAINFLAGS_RELEASE "-O3 -fopenmp -lgomp")
+set(F_TOOLCHAINFLAGS_RELEASE "-O3 -cpp -fopenmp")
 
 # Debug suggestions
-set(CXX_TOOLCHAINFLAGS_DEBUG "-O0 -openmp -Wall")
+set(CXX_TOOLCHAINFLAGS_DEBUG "-O0 -fopenmp -Wall")
 set(F_TOOLCHAINFLAGS_DEBUG "-O0 -cpp -fcheck=all -Wall")

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -1,7 +1,7 @@
 
 if [[ "$TESTOS" == "LINUX" ]]; then
   sudo apt-get update
-  sudo apt-get install gfortran -f
+  sudo apt-get install --reinstall gfortran
   sudo apt-get install libblas-dev liblapack-dev
   sudo apt-get install gawk
   sudo apt-get install clang-format

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -4,7 +4,7 @@ if [[ "$TESTOS" == "LINUX" ]]; then
   sudo apt-get install
   sudo apt-get install libblas-dev liblapack-dev
   sudo apt-get install gawk
-  sudo apt-get install clang-format
+  # sudo apt-get install clang-format
   sudo apt-get install emacs
   sudo apt-get install --reinstall cmake
   if [[ "$MPICH" == "1" ]]; then
@@ -40,6 +40,6 @@ else
   sudo pip install pyyaml --upgrade
 fi
 
-test -n $CC  && unset CC
-test -n $FCC  && unset FCC
-test -n $CXX && unset CXX
+# test -n $CC  && unset CC
+# test -n $FCC  && unset FCC
+# test -n $CXX && unset CXX

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -23,11 +23,11 @@ if [[ "$TESTOS" == "OSX" ]]; then
   brew install swig
   brew install clang-format
   brew install emacs
-  sudo pip2 install numpy --upgrade --no-cache-dir
-  sudo pip2 install scipy --upgrade --no-cache-dir
-  sudo pip2 install mpi4py --upgrade --no-cache-dir
-  sudo pip2 install flake8 --upgrade --no-cache-dir
-  sudo pip2 install pyyaml --upgrade --no-cache-dir
+  sudo pip install numpy --upgrade --no-cache-dir
+  sudo pip install scipy --upgrade --no-cache-dir
+  sudo pip install mpi4py --upgrade --no-cache-dir
+  sudo pip install flake8 --upgrade --no-cache-dir
+  sudo pip install pyyaml --upgrade --no-cache-dir
 else
   sudo ldconfig
   sudo apt-get install python-dev python-pip python-all-dev

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -23,11 +23,11 @@ if [[ "$TESTOS" == "OSX" ]]; then
   brew install swig
   brew install clang-format
   brew install emacs
-  sudo pip install numpy --upgrade --no-cache-dir
-  sudo pip install scipy --upgrade --no-cache-dir
-  sudo pip install mpi4py --upgrade --no-cache-dir
-  sudo pip install flake8 --upgrade --no-cache-dir
-  sudo pip install pyyaml --upgrade --no-cache-dir
+  sudo pip3 install numpy --upgrade --no-cache-dir
+  sudo pip3 install scipy --upgrade --no-cache-dir
+  sudo pip3 install mpi4py --upgrade --no-cache-dir
+  sudo pip3 install flake8 --upgrade --no-cache-dir
+  sudo pip3 install pyyaml --upgrade --no-cache-dir
 else
   sudo ldconfig
   sudo apt-get install python-dev python-pip python-all-dev

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -1,7 +1,7 @@
 
 if [[ "$TESTOS" == "LINUX" ]]; then
   sudo apt-get update
-  sudo apt-get install --reinstall gfortran
+  sudo apt-get install
   sudo apt-get install libblas-dev liblapack-dev
   sudo apt-get install gawk
   sudo apt-get install clang-format

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -6,7 +6,7 @@ if [[ "$TESTOS" == "LINUX" ]]; then
   sudo apt-get install gawk
   # sudo apt-get install clang-format
   sudo apt-get install emacs
-  sudo apt-get install --reinstall cmake
+  # sudo apt-get install --reinstall cmake
   if [[ "$MPICH" == "1" ]]; then
     sudo apt-get install mpich libmpich-dev
   else
@@ -29,7 +29,7 @@ if [[ "$TESTOS" == "OSX" ]]; then
   sudo pip3 install flake8 --upgrade --no-cache-dir
   sudo pip3 install pyyaml --upgrade --no-cache-dir
 else
-  sudo ldconfig
+  # sudo ldconfig
   sudo apt-get install python-dev python-pip python-all-dev
   sudo apt-get install python-setuptools python-wheel
   sudo apt-get install swig
@@ -40,6 +40,7 @@ else
   sudo pip install pyyaml --upgrade
 fi
 
+echo $CC $FCC $CXX
 # test -n $CC  && unset CC
 # test -n $FCC  && unset FCC
 # test -n $CXX && unset CXX

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -43,6 +43,3 @@ else
   sudo pip install pyyaml --upgrade
   sudo pip install ford --upgrade
 fi
-
-echo "HERE"
-mpicxx --version

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -1,7 +1,6 @@
 
 if [[ "$TESTOS" == "LINUX" ]]; then
   sudo apt-get update
-  sudo apt-get install
   sudo apt-get install libblas-dev liblapack-dev
   sudo apt-get install gawk
   sudo apt-get install doxygen
@@ -32,7 +31,6 @@ if [[ "$TESTOS" == "OSX" ]]; then
   sudo pip3 install pyyaml --upgrade --no-cache-dir
   sudo pip3 install ford --upgrade --no-cache-dir
 else
-  # sudo ldconfig
   sudo apt-get install python-dev python-pip python-all-dev
   sudo apt-get install python-setuptools python-wheel
   sudo apt-get install swig

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -1,7 +1,7 @@
 
 if [[ "$TESTOS" == "LINUX" ]]; then
   sudo apt-get update
-  sudo apt-get install gfortran
+  sudo apt-get install gfortran -f
   sudo apt-get install libblas-dev liblapack-dev
   sudo apt-get install gawk
   sudo apt-get install clang-format

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -44,3 +44,5 @@ else
   sudo pip install ford --upgrade
 fi
 
+echo "HERE"
+mpicxx --version

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -7,6 +7,7 @@ if [[ "$TESTOS" == "LINUX" ]]; then
   sudo apt-get install doxygen
   sudo apt-get install clang-format
   sudo apt-get install emacs
+  sudo apt-get install ninja-build
   if [[ "$MPICH" == "1" ]]; then
     sudo apt-get install mpich libmpich-dev
   else
@@ -23,6 +24,7 @@ if [[ "$TESTOS" == "OSX" ]]; then
   brew install swig
   brew install clang-format
   brew install emacs
+  brew install ninja
   sudo pip3 install numpy --upgrade --no-cache-dir
   sudo pip3 install scipy --upgrade --no-cache-dir
   sudo pip3 install mpi4py --upgrade --no-cache-dir

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -14,7 +14,7 @@ if [[ "$TESTOS" == "LINUX" ]]; then
 fi
 
 if [[ "$TESTOS" == "OSX" ]]; then
-  brew install gcc
+  brew reinstall gcc
   brew link --overwrite gcc
   brew install open-mpi
   brew install doxygen

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -4,9 +4,9 @@ if [[ "$TESTOS" == "LINUX" ]]; then
   sudo apt-get install
   sudo apt-get install libblas-dev liblapack-dev
   sudo apt-get install gawk
-  # sudo apt-get install clang-format
+  sudo apt-get install doxygen
+  sudo apt-get install clang-format
   sudo apt-get install emacs
-  # sudo apt-get install --reinstall cmake
   if [[ "$MPICH" == "1" ]]; then
     sudo apt-get install mpich libmpich-dev
   else
@@ -28,6 +28,7 @@ if [[ "$TESTOS" == "OSX" ]]; then
   sudo pip3 install mpi4py --upgrade --no-cache-dir
   sudo pip3 install flake8 --upgrade --no-cache-dir
   sudo pip3 install pyyaml --upgrade --no-cache-dir
+  sudo pip3 install ford --upgrade --no-cache-dir
 else
   # sudo ldconfig
   sudo apt-get install python-dev python-pip python-all-dev
@@ -38,9 +39,6 @@ else
   sudo pip install mpi4py --upgrade
   sudo pip install flake8 --upgrade
   sudo pip install pyyaml --upgrade
+  sudo pip install ford --upgrade
 fi
 
-echo $CC $FCC $CXX
-# test -n $CC  && unset CC
-# test -n $FCC  && unset FCC
-# test -n $CXX && unset CXX

--- a/UnitTests/before_install.sh
+++ b/UnitTests/before_install.sh
@@ -6,6 +6,7 @@ if [[ "$TESTOS" == "LINUX" ]]; then
   sudo apt-get install gawk
   sudo apt-get install clang-format
   sudo apt-get install emacs
+  sudo apt-get install --reinstall cmake
   if [[ "$MPICH" == "1" ]]; then
     sudo apt-get install mpich libmpich-dev
   else

--- a/UnitTests/run_cmake.sh
+++ b/UnitTests/run_cmake.sh
@@ -1,6 +1,6 @@
 if [[ "$TESTOS" == "OSX" ]]; then
   cmake .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Mac-python2.cmake \
-    -DCMAKE_BUILD_TYPE=Release -DPythonInterp=python3 ;
+    -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=python3 ;
 else
   if  [ ! -z ${NOIALLGATHER+x} ]; then
     cmake .. \

--- a/UnitTests/run_cmake.sh
+++ b/UnitTests/run_cmake.sh
@@ -1,6 +1,6 @@
 if [[ "$TESTOS" == "OSX" ]]; then
   cmake .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Mac-python2.cmake \
-    -DCMAKE_BUILD_TYPE=Release ;
+    -DCMAKE_BUILD_TYPE=Release -DPythonInterp=python3 ;
 else
   if  [ ! -z ${NOIALLGATHER+x} ]; then
     cmake .. \

--- a/UnitTests/run_cmake.sh
+++ b/UnitTests/run_cmake.sh
@@ -1,15 +1,15 @@
 if [[ "$TESTOS" == "OSX" ]]; then
-  cmake -G ninja .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Mac-python3.cmake \
+  cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Mac-python3.cmake \
     -DCMAKE_BUILD_TYPE=Release ;
 else
   if  [ ! -z ${NOIALLGATHER+x} ]; then
-    cmake -G ninja .. \
+    cmake -G Ninja .. \
           -DCMAKE_BUILD_TYPE=Debug -DNOIALLGATHER=YES;
   elif [ ! -z ${DEBUG+x} ]; then
-    cmake -G ninja .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Linux.cmake \
+    cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Linux.cmake \
           -DCMAKE_BUILD_TYPE=Debug ;
   else
-    cmake -G ninja .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Linux.cmake \
+    cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Linux.cmake \
           -DCMAKE_BUILD_TYPE=Release ;
   fi
 fi

--- a/UnitTests/run_cmake.sh
+++ b/UnitTests/run_cmake.sh
@@ -1,6 +1,6 @@
 if [[ "$TESTOS" == "OSX" ]]; then
-  cmake .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Mac-python2.cmake \
-    -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=python3 ;
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Mac-python3.cmake \
+    -DCMAKE_BUILD_TYPE=Release ;
 else
   if  [ ! -z ${NOIALLGATHER+x} ]; then
     cmake .. \

--- a/UnitTests/run_cmake.sh
+++ b/UnitTests/run_cmake.sh
@@ -1,15 +1,15 @@
 if [[ "$TESTOS" == "OSX" ]]; then
-  cmake .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Mac-python3.cmake \
+  cmake -G ninja .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Mac-python3.cmake \
     -DCMAKE_BUILD_TYPE=Release ;
 else
   if  [ ! -z ${NOIALLGATHER+x} ]; then
-    cmake .. \
+    cmake -G ninja .. \
           -DCMAKE_BUILD_TYPE=Debug -DNOIALLGATHER=YES;
   elif [ ! -z ${DEBUG+x} ]; then
-    cmake .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Linux.cmake \
+    cmake -G ninja .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Linux.cmake \
           -DCMAKE_BUILD_TYPE=Debug ;
   else
-    cmake .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Linux.cmake \
+    cmake -G ninja .. -DCMAKE_TOOLCHAIN_FILE=../Targets/Linux.cmake \
           -DCMAKE_BUILD_TYPE=Release ;
   fi
 fi


### PR DESCRIPTION
Improvements/Bug Fixes for CI.

Major fix:
1. -fopenmp had to replace -openmp -lgomp otherwise the code cryptically fails to compile. #166
2. Mac require reinstall gcc for some reason

ETC
1. Switched Make to Ninja.
2. Upload artifacts so that you can debug easier.
3. Removed some unneeded packages/
4. Added doxygen/Ford. In the future we should auto-deploy documentation.
5. Mac goes to python3
6. Removed some lines that are artifacts of Travis-CI
