### PR TITLE
Draft: Fix max thread capping issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         name:             [mac, ubuntu-mpich, ubuntu-standard, ubuntu-debug,
-                           ubuntu-nogather]
+                           ubuntu-nogather, ubuntu-mpich-nt]
         include:
           - name:         ubuntu-standard
             os:           ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         name:             [mac, ubuntu-mpich, ubuntu-standard, ubuntu-debug,
-                           ubuntu-nogather, ubuntu-mpich-nt]
+                           ubuntu-nogather, mac-thread-cap]
         include:
           - name:         ubuntu-standard
             os:           ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
             noalligather: 0
             mpich:        1
             threadoff:    0
-          - name:         ubuntu-mpich-nt
+          - name:         mac-thread-cap
             os:           macos-latest
             testos:       OSX
             maketest:     "ctest -R Regression111"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
             mpich:        1
             threadoff:    0
           - name:         ubuntu-mpich-nt
-            os:           ubuntu-latest
-            testos:       LINUX
+            os:           macos-latest
+            testos:       OSX
             maketest:     "ctest -R Regression111"
             testexamples: 0
             debug:        0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             testexamples: 0
             debug:        0
             noalligather: 0
-            mpich:        1
+            mpich:        0
             threadoff:    1
           - name:         mac
             os:           macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       env:
         MAKETEST:         ${{ matrix.maketest }}
         TESTOS:           ${{ matrix.testos }}
+        THREADOFF:        ${{ matrix.threadoff }}
     - name:               check examples
       run:                |
         bash -l UnitTests/check_examples.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        0
-	    threadoff:    0
+            threadoff:    0
           - name:         ubuntu-debug
             os:           ubuntu-latest
             testos:       LINUX
@@ -25,7 +25,7 @@ jobs:
             debug:        1
             noalligather: 0
             mpich:        0
-	    threadoff:    0
+            threadoff:    0
           - name:         ubuntu-nogather
             os:           ubuntu-latest
             testos:       LINUX
@@ -34,7 +34,7 @@ jobs:
             debug:        0
             noalligather: 1
             mpich:        0
-	    threadoff:    0
+            threadoff:    0
           - name:         ubuntu-mpich
             os:           ubuntu-latest
             testos:       LINUX
@@ -43,7 +43,7 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        1
-	    threadoff:    0
+            threadoff:    0
           - name:         ubuntu-mpich-nt
             os:           ubuntu-latest
             testos:       LINUX
@@ -52,7 +52,7 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        1
-	    threadoff:    1
+            threadoff:    1
           - name:         mac
             os:           macos-latest
             testos:       OSX
@@ -62,7 +62,7 @@ jobs:
             noalligather: 0
             mpich:        0
             lint:         1
-	    threadoff:    0
+            threadoff:    0
     runs-on:              ${{ matrix.os }}
     steps:
     - uses:               actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        0
+	    threadoff:    0
           - name:         ubuntu-debug
             os:           ubuntu-latest
             testos:       LINUX
@@ -24,6 +25,7 @@ jobs:
             debug:        1
             noalligather: 0
             mpich:        0
+	    threadoff:    0
           - name:         ubuntu-nogather
             os:           ubuntu-latest
             testos:       LINUX
@@ -32,6 +34,7 @@ jobs:
             debug:        0
             noalligather: 1
             mpich:        0
+	    threadoff:    0
           - name:         ubuntu-mpich
             os:           ubuntu-latest
             testos:       LINUX
@@ -40,6 +43,16 @@ jobs:
             debug:        0
             noalligather: 0
             mpich:        1
+	    threadoff:    0
+          - name:         ubuntu-mpich-nt
+            os:           ubuntu-latest
+            testos:       LINUX
+            maketest:     "ctest -R Regression111"
+            testexamples: 0
+            debug:        0
+            noalligather: 0
+            mpich:        1
+	    threadoff:    1
           - name:         mac
             os:           macos-latest
             testos:       OSX
@@ -49,6 +62,7 @@ jobs:
             noalligather: 0
             mpich:        0
             lint:         1
+	    threadoff:    0
     runs-on:              ${{ matrix.os }}
     steps:
     - uses:               actions/checkout@v1

--- a/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
+++ b/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
@@ -232,6 +232,7 @@
            END SELECT
         END DO
      END DO
+     !$OMP taskwait
   END DO
   !$OMP END MASTER
   !$OMP END PARALLEL

--- a/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
+++ b/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
@@ -233,7 +233,7 @@
         END DO
      END DO
      !! Prevent deadlock in the case where the number of tasks is capped.
-     IF (matA%process_grid%omp_max_threads .EQ. 1) THEN
+     IF (matA%process_grid%omp_max_threads .EQ. 1 .AND. .FALSE.) THEN
         !$OMP taskwait
      END IF
   END DO

--- a/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
+++ b/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
@@ -233,7 +233,7 @@
         END DO
      END DO
      !! Prevent deadlock in the case where the number of tasks is capped.
-     IF (matA%process_grid%omp_max_threads .EQ. 1 .AND. .FALSE.) THEN
+     IF (matA%process_grid%omp_max_threads .EQ. 1) THEN
         !$OMP taskwait
      END IF
   END DO

--- a/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
+++ b/Source/Fortran/distributed_algebra_includes/MatrixMultiply.f90
@@ -232,7 +232,10 @@
            END SELECT
         END DO
      END DO
-     !$OMP taskwait
+     !! Prevent deadlock in the case where the number of tasks is capped.
+     IF (matA%process_grid%omp_max_threads .EQ. 1) THEN
+        !$OMP taskwait
+     END IF
   END DO
   !$OMP END MASTER
   !$OMP END PARALLEL

--- a/UnitTests/run_ci_test.sh
+++ b/UnitTests/run_ci_test.sh
@@ -4,6 +4,11 @@ if [[ "$TESTOS" == "LINUX" ]]; then
    conda activate ntpoly-conda
 fi
 
+if [[ "$threadoff" == "1" ]]; then
+   export OMP_NUM_THREADS=1
+   echo "Setting threads to 1"
+fi
+
 cd Build
 export CTEST_OUTPUT_ON_FAILURE=1
 eval "$MAKETEST"

--- a/UnitTests/run_ci_test.sh
+++ b/UnitTests/run_ci_test.sh
@@ -4,6 +4,9 @@ if [[ "$TESTOS" == "LINUX" ]]; then
    conda activate ntpoly-conda
 fi
 
+echo "Thread Variable"
+echo $threadoff
+
 if [[ "$threadoff" == "1" ]]; then
    export OMP_NUM_THREADS=1
    echo "Setting threads to 1"

--- a/UnitTests/run_ci_test.sh
+++ b/UnitTests/run_ci_test.sh
@@ -4,10 +4,7 @@ if [[ "$TESTOS" == "LINUX" ]]; then
    conda activate ntpoly-conda
 fi
 
-echo "Thread Variable"
-echo $threadoff
-
-if [[ "$threadoff" == "1" ]]; then
+if [[ "$THREADOFF" == "1" ]]; then
    export OMP_NUM_THREADS=1
    echo "Setting threads to 1"
 fi


### PR DESCRIPTION
~~Draft until performance tests confirm no degradation.~~

Fix for #143, where the code hangs if the maximum number of threads is set to 1. It seems that OpenMPI has this issue too now.

What seems to happen is that the task scheduling thread never sleeps, so no calculations are actually done, and a deadlock is reached. I think other implementations of MPI (Fujitsu, Intel, older OpenMPI) would have the main thread sleep during the polling operations, so this wasn't an issue. This is the most brute force of fixes: if the threads are capped, we force task wait. But this may imply that if you're using openmpi there will be performance left on the table, so it could be worth another look in the future.