### PR TITLE
Small fixes for Fortran MPI datatypes and Module

### DIFF
--- a/Source/Fortran/CholeskySolversModule.F90
+++ b/Source/Fortran/CholeskySolversModule.F90
@@ -12,7 +12,7 @@ MODULE CholeskyModule
   USE TripletListModule, ONLY : TripletList_r, AppendToTripletList, &
        & DestructTripletList
   USE TripletModule, ONLY : Triplet_r
-  USE MPI
+  USE NTMPIModule
   IMPLICIT NONE
   PRIVATE
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/Source/Fortran/DataTypesModule.F90
+++ b/Source/Fortran/DataTypesModule.F90
@@ -17,6 +17,6 @@ MODULE DataTypesModule
   !> A long integer type for when normal ints will not do
   INTEGER, PARAMETER, PUBLIC :: NTLONG = C_LONG
   !> MPI Integer type we will use in this program.
-  INTEGER, PARAMETER, PUBLIC :: MPINTINTEGER = MPI_INT
+  INTEGER, PARAMETER, PUBLIC :: MPINTINTEGER = MPI_INTEGER
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 END MODULE DataTypesModule

--- a/Source/Fortran/TimerModule.F90
+++ b/Source/Fortran/TimerModule.F90
@@ -128,7 +128,7 @@ CONTAINS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     DO timer_position = LBOUND(timer_list,dim=1), UBOUND(timer_list,dim=1)
        elapsed = elapsed_times(timer_position)
-       CALL MPI_Allreduce(elapsed, max_time, 1, MPI_DOUBLE ,MPI_MAX, &
+       CALL MPI_Allreduce(elapsed, max_time, 1, MPI_DOUBLE_PRECISION ,MPI_MAX, &
             & global_grid%global_comm, ierr)
        CALL WriteElement(key=timer_list(timer_position), &
             & VALUE=max_time)


### PR DESCRIPTION
There were three small bugs related to Fortran MPI datatypes and the MPI module scheme, which popped up during the compilation of FHI-aims in serial mode. 