### PR TITLE
Fix I/O for large number of entries (> integer)

### DIFF
--- a/Source/Fortran/DataTypesModule.F90
+++ b/Source/Fortran/DataTypesModule.F90
@@ -18,5 +18,7 @@ MODULE DataTypesModule
   INTEGER, PARAMETER, PUBLIC :: NTLONG = C_LONG
   !> MPI Integer type we will use in this program.
   INTEGER, PARAMETER, PUBLIC :: MPINTINTEGER = MPI_INTEGER
+  !> MPI Integer type we will use in this program.
+  INTEGER, PARAMETER, PUBLIC :: MPINTLONG = MPI_LONG
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 END MODULE DataTypesModule

--- a/Source/Fortran/PSMatrixModule.F90
+++ b/Source/Fortran/PSMatrixModule.F90
@@ -2,7 +2,7 @@
 !> A Module For Performing Distributed Sparse Matrix Operations.
 MODULE PSMatrixModule
   USE DataTypesModule, ONLY : NTREAL, MPINTREAL, NTCOMPLEX, MPINTCOMPLEX, &
-       & MPINTINTEGER, NTLONG
+       & MPINTINTEGER, NTLONG, MPINTLONG
   USE ErrorModule, ONLY : Error_t, ConstructError, SetGenericError, &
        & CheckMPIError
   USE LoggingModule, ONLY : EnterSubLog, ExitSubLog, WriteElement, &
@@ -361,7 +361,8 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     TYPE(Triplet_r) :: temp_triplet_r
     TYPE(TripletList_c) :: triplet_list_c
     TYPE(Triplet_c) :: temp_triplet_c
-    INTEGER :: matrix_rows, matrix_columns, total_values
+    INTEGER :: matrix_rows, matrix_columns
+    INTEGER(NTLONG) :: total_values
     !! Length Variables
     INTEGER :: header_length
     INTEGER(KIND=MPI_OFFSET_KIND) :: total_file_size
@@ -427,7 +428,7 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             & process_grid_in%global_comm, ierr)
        CALL MPI_Bcast(matrix_columns, 1, MPINTINTEGER, process_grid_in%RootID, &
             & process_grid_in%global_comm, ierr)
-       CALL MPI_Bcast(total_values, 1, MPINTINTEGER, process_grid_in%RootID, &
+       CALL MPI_Bcast(total_values, 1, MPINTLONG, process_grid_in%RootID, &
             & process_grid_in%global_comm, ierr)
        CALL MPI_Bcast(header_length, 1, MPINTINTEGER, process_grid_in%RootID, &
             & process_grid_in%global_comm, ierr)

--- a/Source/Fortran/PSMatrixModule.F90
+++ b/Source/Fortran/PSMatrixModule.F90
@@ -614,7 +614,7 @@ CONTAINS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           matrix_rows = matrix_information(1)
           matrix_columns = matrix_information(2)
           complex_flag = matrix_information(3)
-          
+
           local_offset = 3 * bytes_per_int
           CALL MPI_File_read_at(mpi_file_handler, local_offset, &
                & total_values, 1, MPINTLONG, message_status, ierr)


### PR DESCRIPTION
When reading a text matrix market matrix, NTPoly was storing the total number of matrix elements into a standard integer. For reading/writing binary, the same issue existed. This fixes those issues.

This modifies the format of the binary matrix in a non-backwards compatible way. This is one more reason to move to version 3. 