### PR TITLE
Make the compute grid size function public

### DIFF
--- a/Source/Fortran/ProcessGridModule.F90
+++ b/Source/Fortran/ProcessGridModule.F90
@@ -68,6 +68,7 @@ MODULE ProcessGridModule
   PUBLIC :: GetMySlice
   PUBLIC :: GetMyRow
   PUBLIC :: GetMyColumn
+  PUBLIC :: ComputeGridSize
   PUBLIC :: WriteProcessGridInfo
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   INTERFACE ConstructProcessGrid


### PR DESCRIPTION
It's useful for the calling code to be able to compute